### PR TITLE
Fixing the issue mentioned in https://github.com/okta/okta-spring-boot/issues/25

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/oauth/OktaPropertiesMappingEnvironmentPostProcessor.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/OktaPropertiesMappingEnvironmentPostProcessor.java
@@ -137,8 +137,7 @@ public class OktaPropertiesMappingEnvironmentPostProcessor implements Environmen
                 OidcDiscoveryMetadata discoveryMetadata = new OidcDiscoveryClient(issuerUrl).discover();
                 Map<String, String> tmpValues = new HashMap<>();
 
-                String baseUrl = issuerUrl.substring(0, issuerUrl.lastIndexOf("/oauth2/"));
-                tmpValues.put("okta.client.orgUrl", baseUrl);
+                tmpValues.put("okta.client.orgUrl", issuerUrl);
                 tmpValues.put(OAUTH_CLIENT_PREFIX + "accessTokenUri", discoveryMetadata.getTokenEndpoint());
                 tmpValues.put(OAUTH_CLIENT_PREFIX + "userAuthorizationUri", discoveryMetadata.getAuthorizationEndpoint());
                 tmpValues.put(OAUTH_RESOURCE_PREFIX + "userInfoUri", discoveryMetadata.getUserinfoEndpoint());

--- a/src/ci/before_install.sh
+++ b/src/ci/before_install.sh
@@ -34,7 +34,7 @@ export ARTIFACT_VERSION="$(xmllint --xpath "//*[local-name()='project']/*[local-
 export IS_RELEASE="$([ ${ARTIFACT_VERSION/SNAPSHOT} == $ARTIFACT_VERSION ] && [ $TRAVIS_BRANCH == 'master' ] && echo 'true')"
 
 #Install newer Maven since Travis uses 3.2 by default
-wget http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.zip
+wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${MVN_VERSION}/apache-maven-${MVN_VERSION}-bin.zip
 unzip -qq apache-maven-${MVN_VERSION}-bin.zip -d ..
 rm apache-maven-${MVN_VERSION}-bin.zip
 export M2_HOME=$PWD/../apache-maven-${MVN_VERSION}


### PR DESCRIPTION

The problem encountered was that the issuerUrl mentioned on the oktapreview.com admin domain no longer uses the /oauth2/default location.  The code was giving a StringIndexOutOfBoundsException on using the issuerUrl as mentioned on the UI.  I strongly feel there is no need for a base URL anymore and issuer URL is enough for the application to work.  The other workaround can be to check if the issuerUrl does contain /oauth2/, if it does extract the base url else continue with the issuerUrl.