### PR TITLE
Lazy loading properties configured via OIDC discovery and OktaPropertiesMappingEnvironmentPostProcessor

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/oauth/OktaPropertiesMappingEnvironmentPostProcessor.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/OktaPropertiesMappingEnvironmentPostProcessor.java
@@ -90,7 +90,8 @@ public class OktaPropertiesMappingEnvironmentPostProcessor implements Environmen
     @Override
     public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
         environment.getPropertySources().addLast(remappedOktaToStandardOAuthPropertySource(environment));
-        environment.getPropertySources().addLast(loadYaml(new FileSystemResource(new File(System.getProperty("user.home"), "okta/okta.yml")), false));
+        environment.getPropertySources().addLast(loadYaml(new FileSystemResource(new File(System.getProperty("user.home"), ".okta/okta.yml")), false));
+        environment.getPropertySources().addLast(loadYaml(new FileSystemResource(new File(System.getProperty("user.home"), ".okta/okta.yaml")), false));
         environment.getPropertySources().addLast(new DiscoveryPropertySource(environment));
         environment.getPropertySources().addLast(oauthToClientPropertiesSource(environment));
         environment.getPropertySources().addLast(loadYaml(new ClassPathResource("com/okta/spring/okta.yml"), true));
@@ -109,7 +110,7 @@ public class OktaPropertiesMappingEnvironmentPostProcessor implements Environmen
                 throw new IllegalStateException("Failed to load yaml configuration from " + resource, ex);
             }
         } else {
-            return new MapPropertySource("missing "+ resource.getFilename(), Collections.emptyMap());
+            return new MapPropertySource("Missing "+ resource.getFilename(), Collections.emptyMap());
         }
     }
 
@@ -154,7 +155,7 @@ public class OktaPropertiesMappingEnvironmentPostProcessor implements Environmen
             String orgUrlKey = "okta.client.orgUrl";
             if (orgUrlKey.equals(name)) {
                 // first lookup the issuer
-                String issuerUrl = environment.getProperty(OKTA_OAUTH_PREFIX +"issuer");
+                String issuerUrl = environment.getProperty(OKTA_OAUTH_PREFIX + "issuer");
                 // if we don't have one just return null
                 if (StringUtils.hasText(issuerUrl)) {
                     return issuerUrl.substring(0, issuerUrl.lastIndexOf("/oauth2/"));

--- a/oauth2/src/main/java/com/okta/spring/oauth/OktaTokenServicesConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/OktaTokenServicesConfig.java
@@ -37,6 +37,7 @@ import org.springframework.security.oauth2.provider.token.store.IssuerClaimVerif
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
 import org.springframework.security.oauth2.provider.token.store.JwtClaimsSetVerifier;
 import org.springframework.security.oauth2.provider.token.store.jwk.JwkTokenStore;
+import org.springframework.util.StringUtils;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -114,6 +115,11 @@ public class OktaTokenServicesConfig {
         @Bean
         @ConditionalOnMissingBean
         public JwtClaimsSetVerifier jwtClaimsSetVerifier() {
+
+            if (!StringUtils.hasText(oktaOAuth2Properties.getIssuer())) {
+                throw new InvalidPropertyException(JwtClaimsSetVerifier.class, "okta.oauth2.issuer", "Property 'okta.oauth2.issuer' is required.");
+            }
+
             try {
                 return new IssuerClaimVerifier(new URL(oktaOAuth2Properties.getIssuer()));
             } catch (MalformedURLException e) {

--- a/oauth2/src/main/java/com/okta/spring/oauth/RemappedPropertySource.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/RemappedPropertySource.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.spring.oauth;
+
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link PropertySource} that supports aliasing/renaming of keys.  For alias the key {code}foo{code} to the key
+ * {code}{bar}{code} whenever either of the values are looked up they will return the same value. This differs from setting
+ * {code}foo=${bar}{code}, in that if the value of {code}bar{code} is {code}null{code}, {code}null{code} is returned,
+ * if {code}${bar}{code} was used, an exception would be thrown due to the unresolvable property {code}bar{code}.
+ * 
+ * @since 0.3.0
+ */
+public class RemappedPropertySource extends EnumerablePropertySource<String> {
+
+    private final Map<String, String> aliasMap = new HashMap<>();
+    private final Environment environment;
+
+    public RemappedPropertySource(Map<String, String> aliasMap, Environment environment) {
+        super("okta-to-oauth2");
+        this.aliasMap.putAll(aliasMap);
+        this.environment = environment;
+    }
+
+    @Override
+    public Object getProperty(String name) {
+
+        String remappedKey = aliasMap.get(name);
+        if (remappedKey != null) {
+            return environment.getProperty(remappedKey);
+        }
+
+        return null;
+    }
+
+    @Override
+    public String[] getPropertyNames() {
+        return aliasMap.keySet().toArray(new String[aliasMap.size()]);
+    }
+}

--- a/oauth2/src/main/java/com/okta/spring/oauth/discovery/DiscoveryPropertySource.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/discovery/DiscoveryPropertySource.java
@@ -102,15 +102,17 @@ public class DiscoveryPropertySource extends EnumerablePropertySource<String> {
         if (metadataProperties == null) {
             synchronized (this) {
                 String issuerUrl = environment.getRequiredProperty(OKTA_OAUTH_ISSUER);
-                OidcDiscoveryMetadata discoveryMetadata = new OidcDiscoveryClient(issuerUrl).discover();
-
+                OidcDiscoveryMetadata discoveryMetadata = createDiscoveryClient(issuerUrl).discover();
                 Map<String, Object> tmpValues = new HashMap<>();
-                putIfNotNull(tmpValues, OAUTH_ACCESS_TOKEN_URI_KEY, discoveryMetadata.getTokenEndpoint());
-                putIfNotNull(tmpValues, OAUTH_ACCESS_USER_AUTH_URI_KEY, discoveryMetadata.getAuthorizationEndpoint());
-                putIfNotNull(tmpValues, OAUTH_ACCESS_USER_INFO_URI_KEY, discoveryMetadata.getUserinfoEndpoint());
-                putIfNotNull(tmpValues, OAUTH_RESOURCE_JWT_KEY_SET_URI_KEY, discoveryMetadata.getJwksUri());
-                putIfNotNull(tmpValues, OAUTH_RESOURCE_JWT_KEY_SET_URI_DASH_KEY, discoveryMetadata.getJwksUri());
-                putIfNotNull(tmpValues, OAUTH_RESOURCE_TOKEN_INFO_URI, discoveryMetadata.getIntrospectionEndpoint());
+
+                if (discoveryMetadata != null) {
+                    putIfNotNull(tmpValues, OAUTH_ACCESS_TOKEN_URI_KEY, discoveryMetadata.getTokenEndpoint());
+                    putIfNotNull(tmpValues, OAUTH_ACCESS_USER_AUTH_URI_KEY, discoveryMetadata.getAuthorizationEndpoint());
+                    putIfNotNull(tmpValues, OAUTH_ACCESS_USER_INFO_URI_KEY, discoveryMetadata.getUserinfoEndpoint());
+                    putIfNotNull(tmpValues, OAUTH_RESOURCE_JWT_KEY_SET_URI_KEY, discoveryMetadata.getJwksUri());
+                    putIfNotNull(tmpValues, OAUTH_RESOURCE_JWT_KEY_SET_URI_DASH_KEY, discoveryMetadata.getJwksUri());
+                    putIfNotNull(tmpValues, OAUTH_RESOURCE_TOKEN_INFO_URI, discoveryMetadata.getIntrospectionEndpoint());
+                }
                 metadataProperties = tmpValues;
             }
         }
@@ -121,5 +123,9 @@ public class DiscoveryPropertySource extends EnumerablePropertySource<String> {
         if (value != null) {
             map.put(key, value);
         }
+    }
+
+    OidcDiscoveryClient createDiscoveryClient(String issuerUrl) {
+        return  new OidcDiscoveryClient(issuerUrl);
     }
 }

--- a/oauth2/src/main/java/com/okta/spring/oauth/discovery/DiscoveryPropertySource.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/discovery/DiscoveryPropertySource.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.spring.oauth.discovery;
+
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link org.springframework.core.env.PropertySource PropertySource} that maps the values from an OIDC discovery
+ * metadata endpoint to Spring Security's expected {code}security.oauth2.*{code} properties.
+ * <p>
+ * NOTE: Discovery can be disabled by setting the property {code}okta.oauth2.discoveryDisabled=true{code}.
+ *
+ * @since 0.3.0
+ */
+public class DiscoveryPropertySource extends EnumerablePropertySource<String> {
+
+    private static final String OAUTH_CLIENT_PREFIX = "security.oauth2.client.";
+    private static final String OAUTH_RESOURCE_PREFIX = "security.oauth2.resource.";
+    private static final String OKTA_OAUTH_ISSUER = "okta.oauth2.issuer";
+    private static final String OKTA_OAUTH_DISCOVERY_DISABLED = "okta.oauth2.discoveryDisabled";
+
+    private static final String OAUTH_RESOURCE_JWK_SUB_KEY = OAUTH_RESOURCE_PREFIX + "jwk";
+
+    private static final String OAUTH_ACCESS_TOKEN_URI_KEY = OAUTH_CLIENT_PREFIX + "accessTokenUri";
+    private static final String OAUTH_ACCESS_USER_AUTH_URI_KEY = OAUTH_CLIENT_PREFIX + "userAuthorizationUri";
+    private static final String OAUTH_ACCESS_USER_INFO_URI_KEY = OAUTH_RESOURCE_PREFIX + "userInfoUri";
+    private static final String OAUTH_RESOURCE_JWT_KEY_SET_URI_KEY = OAUTH_RESOURCE_JWK_SUB_KEY + ".keySetUri";
+    private static final String OAUTH_RESOURCE_JWT_KEY_SET_URI_DASH_KEY = OAUTH_RESOURCE_JWK_SUB_KEY + ".key-set-uri";
+    private static final String OAUTH_RESOURCE_TOKEN_INFO_URI = OAUTH_RESOURCE_PREFIX + "tokenInfoUri";
+
+    private static final String[] supportedKeys = {OAUTH_ACCESS_TOKEN_URI_KEY,
+                                                   OAUTH_ACCESS_USER_AUTH_URI_KEY,
+                                                   OAUTH_ACCESS_USER_INFO_URI_KEY,
+                                                   OAUTH_RESOURCE_JWK_SUB_KEY,
+                                                   OAUTH_RESOURCE_JWT_KEY_SET_URI_KEY,
+                                                   OAUTH_RESOURCE_JWT_KEY_SET_URI_DASH_KEY,
+                                                   OAUTH_RESOURCE_TOKEN_INFO_URI};
+    private static final List<String> supportedKeysList = Collections.unmodifiableList(Arrays.asList(supportedKeys));
+
+
+    private final boolean isEnabled;
+    private final Environment environment;
+    private Map<String, Object> metadataProperties = null;
+
+    public DiscoveryPropertySource(Environment environment) {
+        super("Okta-OIDC-Discovery-Client");
+        this.environment = environment;
+        this.isEnabled = !Boolean.parseBoolean(environment.getProperty(OKTA_OAUTH_DISCOVERY_DISABLED));
+    }
+
+    @Override
+    public Object getProperty(String name) {
+
+        // there are some cases where 'containsProperty' is not called before calling this method, so we need to guard
+        // against it because we are using the 'environment' direction, otherwise we would end up recursively
+        // calling this method.
+        return containsProperty(name) && isReady()
+            ? getDiscoveryMetadata().get(name)
+            : null;
+    }
+
+    @Override
+    public boolean containsProperty(String name) {
+        return isEnabled && supportedKeysList.contains(name);
+    }
+
+    @Override
+    public String[] getPropertyNames() {
+        return Arrays.copyOf(supportedKeys, supportedKeys.length);
+    }
+
+    private boolean isReady() {
+        return environment.containsProperty(OKTA_OAUTH_ISSUER);
+    }
+
+    private Map<String, Object> getDiscoveryMetadata() {
+
+        if (!isEnabled) {
+            return Collections.emptyMap();
+        }
+
+        // lazy load the properties the first time they are actually used
+        if (metadataProperties == null) {
+            synchronized (this) {
+                String issuerUrl = environment.getRequiredProperty(OKTA_OAUTH_ISSUER);
+                OidcDiscoveryMetadata discoveryMetadata = new OidcDiscoveryClient(issuerUrl).discover();
+
+                Map<String, Object> tmpValues = new HashMap<>();
+                putIfNotNull(tmpValues, OAUTH_ACCESS_TOKEN_URI_KEY, discoveryMetadata.getTokenEndpoint());
+                putIfNotNull(tmpValues, OAUTH_ACCESS_USER_AUTH_URI_KEY, discoveryMetadata.getAuthorizationEndpoint());
+                putIfNotNull(tmpValues, OAUTH_ACCESS_USER_INFO_URI_KEY, discoveryMetadata.getUserinfoEndpoint());
+                putIfNotNull(tmpValues, OAUTH_RESOURCE_JWT_KEY_SET_URI_KEY, discoveryMetadata.getJwksUri());
+                putIfNotNull(tmpValues, OAUTH_RESOURCE_JWT_KEY_SET_URI_DASH_KEY, discoveryMetadata.getJwksUri());
+                putIfNotNull(tmpValues, OAUTH_RESOURCE_TOKEN_INFO_URI, discoveryMetadata.getIntrospectionEndpoint());
+                metadataProperties = tmpValues;
+            }
+        }
+        return metadataProperties;
+    }
+
+    private static void putIfNotNull(Map<String, Object> map, String key, Object value) {
+        if (value != null) {
+            map.put(key, value);
+        }
+    }
+}

--- a/oauth2/src/main/java/com/okta/spring/oauth/discovery/DiscoveryPropertySource.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/discovery/DiscoveryPropertySource.java
@@ -70,7 +70,6 @@ public class DiscoveryPropertySource extends EnumerablePropertySource<String> {
 
     @Override
     public Object getProperty(String name) {
-
         // there are some cases where 'containsProperty' is not called before calling this method, so we need to guard
         // against it because we are using the 'environment' direction, otherwise we would end up recursively
         // calling this method.

--- a/oauth2/src/main/resources/META-INF/spring.factories
+++ b/oauth2/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,4 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration = com.okta.spring.oauth.implicit.ResourceServerConfig,com.okta.spring.oauth.code.OktaOAuthCodeFlowConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration = \
+  com.okta.spring.oauth.implicit.ResourceServerConfig,\
+  com.okta.spring.oauth.code.OktaOAuthCodeFlowConfiguration
 org.springframework.boot.env.EnvironmentPostProcessor=com.okta.spring.oauth.OktaPropertiesMappingEnvironmentPostProcessor

--- a/oauth2/src/test/groovy/com/okta/spring/oauth/discovery/DiscoveryPropertySourceTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/oauth/discovery/DiscoveryPropertySourceTest.groovy
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.spring.oauth.discovery
+
+import org.springframework.core.env.Environment
+import org.testng.annotations.Test
+
+import static org.hamcrest.Matchers.*
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.mockito.Mockito.*
+
+/**
+ * Tests for {@link DiscoveryPropertySource}.
+ *
+ * @since 0.3.0
+ */
+class DiscoveryPropertySourceTest {
+
+    /**
+     * Validates that when disabled, discovery will NOT throw an exception or attempt to make a remote connection.
+     */
+    @Test
+    void disabledDiscoveryTest() {
+        Environment env = mock(Environment)
+        when(env.getProperty("okta.oauth2.discoveryDisabled")).thenReturn("true")
+        DiscoveryPropertySource propertySource = new DiscoveryPropertySource(env)
+
+        assertThat propertySource.containsProperty("security.oauth2.client.accessTokenUri"), equalTo(false)
+        assertThat propertySource.getProperty("security.oauth2.client.userAuthorizationUri"), nullValue()
+    }
+
+    @Test
+    void nullMetadataTest() {
+
+        Environment env = mock(Environment)
+        when(env.containsProperty("okta.oauth2.issuer")).thenReturn(true)
+        when(env.getRequiredProperty("okta.oauth2.issuer")).thenReturn("https://okta.example.com/issuer")
+
+        OidcDiscoveryClient discoveryClient = mock(OidcDiscoveryClient)
+        when(discoveryClient.discover()).thenReturn(null)
+
+        DiscoveryPropertySource propertySource = new DiscoveryPropertySource(env) {
+            @Override
+            OidcDiscoveryClient createDiscoveryClient(String issuerUrl) {
+                return discoveryClient
+            }
+        }
+        assertThat propertySource.getProperty("security.oauth2.client.userAuthorizationUri"), nullValue()
+    }
+
+    @Test
+    void nullMetadataValueTest() {
+
+        Environment env = mock(Environment)
+        when(env.containsProperty("okta.oauth2.issuer")).thenReturn(true)
+        when(env.getRequiredProperty("okta.oauth2.issuer")).thenReturn("https://okta.example.com/issuer")
+
+        OidcDiscoveryMetadata metadata = mock(OidcDiscoveryMetadata)
+        when(metadata.getTokenEndpoint()).thenReturn(null)
+
+        OidcDiscoveryClient discoveryClient = mock(OidcDiscoveryClient)
+        when(discoveryClient.discover()).thenReturn(metadata)
+
+        DiscoveryPropertySource propertySource = new DiscoveryPropertySource(env) {
+            @Override
+            OidcDiscoveryClient createDiscoveryClient(String issuerUrl) {
+                return discoveryClient
+            }
+        }
+        assertThat propertySource.getProperty("security.oauth2.client.accessTokenUri"), nullValue()
+    }
+
+    @Test
+    void metadataValuesTest() {
+
+        Environment env = mock(Environment)
+        when(env.containsProperty("okta.oauth2.issuer")).thenReturn(true)
+        when(env.getRequiredProperty("okta.oauth2.issuer")).thenReturn("https://okta.example.com/issuer")
+
+        OidcDiscoveryMetadata metadata = mock(OidcDiscoveryMetadata)
+        when(metadata.getTokenEndpoint()).thenReturn("tokenEnpoint")
+        when(metadata.getAuthorizationEndpoint()).thenReturn("authorizationEndpoint")
+        when(metadata.getUserinfoEndpoint()).thenReturn("userinfoEndpoint")
+        when(metadata.getJwksUri()).thenReturn("jwksUri")
+        when(metadata.getIntrospectionEndpoint()).thenReturn("introspectionEndpoint")
+
+        OidcDiscoveryClient discoveryClient = mock(OidcDiscoveryClient)
+        when(discoveryClient.discover()).thenReturn(metadata)
+
+        DiscoveryPropertySource propertySource = new DiscoveryPropertySource(env) {
+            @Override
+            OidcDiscoveryClient createDiscoveryClient(String issuerUrl) {
+                return discoveryClient
+            }
+        }
+        assertThat propertySource.getProperty("security.oauth2.client.accessTokenUri"), equalTo("tokenEnpoint")
+        assertThat propertySource.getProperty("security.oauth2.client.userAuthorizationUri"), equalTo("authorizationEndpoint")
+        assertThat propertySource.getProperty("security.oauth2.resource.userInfoUri"), equalTo("userinfoEndpoint")
+        assertThat propertySource.getProperty("security.oauth2.resource.jwk.keySetUri"), equalTo("jwksUri")
+        assertThat propertySource.getProperty("security.oauth2.resource.jwk.key-set-uri"), equalTo("jwksUri")
+        assertThat propertySource.getProperty("security.oauth2.resource.tokenInfoUri"), equalTo("introspectionEndpoint")
+    }
+}

--- a/oauth2/src/test/groovy/com/okta/spring/oauth/discovery/OidcDiscoveryClientTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/oauth/discovery/OidcDiscoveryClientTest.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.spring.oauth.discovery
+
+import org.testng.annotations.Test
+
+/**
+ * Tests for {@link OidcDiscoveryClient}.
+ *
+ * @since 0.3.0
+ */
+class OidcDiscoveryClientTest {
+
+    @Test(expectedExceptions = IllegalArgumentException)
+    void nullIssuerTest() {
+        new OidcDiscoveryClient(null)
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException)
+    void emptyIssuerTest() {
+        new OidcDiscoveryClient("")
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException)
+    void justSpaceIssuerTest() {
+        new OidcDiscoveryClient(" ")
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException)
+    void invalidUriIssuerTest() {
+        new OidcDiscoveryClient(" invalid uri")
+    }
+}

--- a/oauth2/src/test/groovy/com/okta/spring/oauth/implicit/ResourceServerConfigTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/oauth/implicit/ResourceServerConfigTest.groovy
@@ -34,7 +34,8 @@ import static org.hamcrest.Matchers.notNullValue
                 properties = ["okta.oauth2.issuer=https://okta.example.com/oauth2/my_issuer",
                               "okta.oauth2.audience=custom_audience",
                               "okta.oauth2.scopeClaim=custom_scope_claim",
-                              "okta.oauth2.rolesClaim=custom_roles_claim"])
+                              "okta.oauth2.rolesClaim=custom_roles_claim",
+                              "okta.oauth2.discoveryDisabled=true"])
 class ResourceServerConfigTest extends AbstractTestNGSpringContextTests {
 
     @Autowired


### PR DESCRIPTION
Now they work with spring-cloud-config!

Fixes: #26

This could sill use a few UTs in the `discovery` package, but any thoughts?  It feels like should be an easier way to do all of this.  Both the aliasing of the config properties and the injecting of the discovery metadata into the _standard_ spring properties.

There are no tests currently for spring-cloud-config, but I've manually verified that lazy loading the config properties allows for spring-cloud-config to be used to configure the `okta.*` props.