### PR TITLE
Make the SDK truly optional

### DIFF
--- a/integration-tests/oauth2/src/main/java/com/okta/spring/tests/oauth2/code/BasicRedirectCodeFlowApplication.java
+++ b/integration-tests/oauth2/src/main/java/com/okta/spring/tests/oauth2/code/BasicRedirectCodeFlowApplication.java
@@ -17,6 +17,7 @@ package com.okta.spring.tests.oauth2.code;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -31,6 +32,8 @@ import java.security.Principal;
 @SpringBootApplication
 @RestController
 @EnableOAuth2Sso
+// fail loading this config if the SDK 'Client' is found. It should NOT exist on the classpath by default
+@ConditionalOnMissingClass("com.okta.sdk.client.Client")
 public class BasicRedirectCodeFlowApplication {
 
     @EnableGlobalMethodSecurity(prePostEnabled = true)

--- a/okta-spring-boot-starter/pom.xml
+++ b/okta-spring-boot-starter/pom.xml
@@ -38,23 +38,21 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-sdk</artifactId>
-        </dependency>
-
-        <!-- force the SDK to be optional from the starter -->
-        <dependency>
-            <groupId>com.okta.sdk</groupId>
-            <artifactId>okta-sdk-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.okta.sdk</groupId>
-            <artifactId>okta-sdk-impl</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.okta.sdk</groupId>
-            <artifactId>okta-sdk-httpclient</artifactId>
-            <optional>true</optional>
+            <exclusions>
+                <!-- force the SDK to be optional from the starter -->
+                <exclusion>
+                    <groupId>com.okta.sdk</groupId>
+                    <artifactId>okta-sdk-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.okta.sdk</groupId>
+                    <artifactId>okta-sdk-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.okta.sdk</groupId>
+                    <artifactId>okta-sdk-httpclient</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I'm guessing Maven was overriding the 'optional' declaration because those dependencies are NOT optional in one of the transitive dependencies.
Added annotation to BasicRedirectCodeFlowApplication to fail the test if the SDK is on the classpath