### PR TITLE
Add support for Spring Boot 2.0

### DIFF
--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>spring-security-oauth2</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security.oauth.boot</groupId>
+            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
         </dependency>

--- a/oauth2/src/main/java/com/okta/spring/oauth/OktaPropertiesMappingEnvironmentPostProcessor.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/OktaPropertiesMappingEnvironmentPostProcessor.java
@@ -105,7 +105,7 @@ public class OktaPropertiesMappingEnvironmentPostProcessor implements Environmen
 
         if (resource.exists()) {
             try {
-                return loader.load(resource.getFilename(), resource, null);
+                return loader.load(resource.getFilename(), resource).get(0);
             } catch (IOException ex) {
                 throw new IllegalStateException("Failed to load yaml configuration from " + resource, ex);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring-boot.version>1.5.7.RELEASE</spring-boot.version>
+        <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
+        <spring-security.version>5.0.3.RELEASE</spring-security.version>
         <github.slug>okta/okta-spring-boot</github.slug>
         <okta.sdk.version>0.10.0</okta.sdk.version>
     </properties>
@@ -49,8 +50,8 @@
     <dependencyManagement>
         <dependencies>
 
+            <!-- Import dependency management from Spring Boot -->
             <dependency>
-                <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot.version}</version>
@@ -58,11 +59,19 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- User newer oauth2 module, this will be removed when this version is include in the above BOM  -->
+            <!-- Import dependency management from Spring Security -->
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-bom</artifactId>
+                <version>${spring-security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.springframework.security.oauth</groupId>
                 <artifactId>spring-security-oauth2</artifactId>
-                <version>2.2.0.RELEASE</version>
+                <version>2.2.1.RELEASE</version>
                 <exclusions>
                     <!-- don't let these transitive dependencies mess with the bom above -->
                     <exclusion>
@@ -70,6 +79,18 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-jwt</artifactId>
+                <version>1.0.9.RELEASE</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.security.oauth.boot</groupId>
+                <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+                <version>2.0.0.RELEASE</version>
             </dependency>
 
             <dependency>

--- a/sdk/src/main/java/com/okta/spring/sdk/OktaSdkConfig.java
+++ b/sdk/src/main/java/com/okta/spring/sdk/OktaSdkConfig.java
@@ -32,7 +32,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
-import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
@@ -101,7 +100,7 @@ public class OktaSdkConfig {
 
     private CacheManager oktaSdkCacheManager() {
         return (springCacheManager != null) ?
-             new SpringCacheManager(springCacheManager) : null;
+                new SpringCacheManager(springCacheManager) : null;
     }
 
     @Bean
@@ -119,8 +118,7 @@ public class OktaSdkConfig {
         public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
 
             ConditionMessage.Builder message = ConditionMessage.forCondition("Okta Api Token Condition");
-            RelaxedPropertyResolver resolver = new RelaxedPropertyResolver(context.getEnvironment(), "okta.client.");
-            String tokenValue = resolver.getProperty("token");
+            String tokenValue = context.getEnvironment().getProperty("okta.client.token");
             if (StringUtils.hasText(tokenValue)) {
                 return ConditionOutcome.match(message.foundExactly("provided API token"));
             }


### PR DESCRIPTION
This is a proof-of-concept PR that shows it's possible to upgrade to Spring Boot 2.0. Fixes #30 and #39.

I've proven this works in https://github.com/oktadeveloper/okta-spring-boot-2-angular-5-example. However, one strange issue I ran into is:

```
[ERROR] Failed to execute goal org.springframework.boot:spring-boot-maven-plugin:2.0.0.RELEASE:run (default-cli) on project demo: 
An exception occurred while running. null: InvocationTargetException: Error creating bean with name 'oktaSdkClient' defined in class path resource [com/okta/spring/sdk/OktaSdkConfig.class]: 
Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.okta.sdk.client.Client]: 
Factory method 'oktaSdkClient' threw exception; nested exception is java.lang.IllegalArgumentException: baseUrl argument cannot be null. -> [Help 1]
```

Adding a `okta.client.orgUrl` property/value to my `application.properties` fixes this issue.