### PR TITLE
Allow okta.client.org-url to be parsed from okta.oauth2.issuer with Spring Boot 2

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/oauth/OktaPropertiesMappingEnvironmentPostProcessor.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/OktaPropertiesMappingEnvironmentPostProcessor.java
@@ -50,12 +50,12 @@ import java.util.Map;
  *             <th>Spring Boot Property</th>
  *         </tr>
  *         <tr>
- *             <td>okta.oauth2.clientId</td>
- *             <td>security.oauth2.client.clientId</td>
+ *             <td>okta.oauth2.client-id</td>
+ *             <td>security.oauth2.client.client-id</td>
  *         </tr>
  *         <tr>
- *             <td>okta.oauth2.clientSecret</td>
- *             <td>security.oauth2.client.clientSecret</td>
+ *             <td>okta.oauth2.client-secret</td>
+ *             <td>security.oauth2.client.client-secret</td>
  *         </tr>
  *     </table>
  * Discovery properties:
@@ -67,18 +67,18 @@ import java.util.Map;
  *         </tr>
  *         <tr>
  *             <td>OidcDiscoveryMetadata.getTokenEndpoint()</td>
- *             <td>security.oauth2.client.accessTokenUri</td>
+ *             <td>security.oauth2.client.access-token-uri</td>
  *         </tr>
  *         <tr>
  *             <td>OidcDiscoveryMetadata.getAuthorizationEndpoint()</td>
- *             <td>security.oauth2.client.userAuthorizationUri</td>
+ *             <td>security.oauth2.client.user-authorization-uri</td>
  *         </tr>
  *         <tr>
  *             <td>OidcDiscoveryMetadata.getUserinfoEndpoint()</td>
- *             <td>security.oauth2.resource.userInfoUri</td>
+ *             <td>security.oauth2.resource.user-info-uri</td>
  *         </tr>
  *     </table>
- * As well as updating default properties values from 'com.okta.spring.okta.yml'. And setting 'okta.client.orgUrl' based
+ * As well as updating default properties values from 'com.okta.spring.okta.yml'. And setting 'okta.client.org-url' based
  * on 'okta.oauth2.issuer'
  *
  * NOTE: for discovery can be disabled by setting the property {code}okta.oauth2.discoveryDisabled=true{code}.
@@ -134,14 +134,16 @@ public class OktaPropertiesMappingEnvironmentPostProcessor implements Environmen
      */
     private PropertySource remappedOktaToStandardOAuthPropertySource(Environment environment) {
         Map<String, String> aliasMap = new HashMap<>();
+
+        // when we drop Spring Boot 1.x support these properties should be changed to kabab format
         aliasMap.put(OAUTH_CLIENT_PREFIX + "clientId", OKTA_OAUTH_PREFIX + "clientId");
         aliasMap.put(OAUTH_CLIENT_PREFIX + "clientSecret", OKTA_OAUTH_PREFIX + "clientSecret");
         aliasMap.put(OAUTH_RESOURCE_PREFIX + "serviceId", OKTA_OAUTH_PREFIX + "audience");
-        return new RemappedPropertySource(aliasMap, environment);
+        return new RemappedPropertySource("okta-to-oauth2", aliasMap, environment);
     }
 
     /**
-     * Maps the baseUrl of {code}okta.oauth2.issuer{code} to {code}okta.client.orgUrl{code}.
+     * Maps the baseUrl of {code}okta.oauth2.issuer{code} to {code}okta.client.org-url{code}.
      * @param environment Environment used to read the {code}okta.oauth2.*{code} properties from.
      * @return A PropertySource containing the newly mapped values.
      */
@@ -165,8 +167,7 @@ public class OktaPropertiesMappingEnvironmentPostProcessor implements Environmen
 
         @Override
         public Object getProperty(String name) {
-            String orgUrlKey = "okta.client.orgUrl";
-            if (orgUrlKey.equals(name)) {
+            if (containsProperty(name)) {
                 // first lookup the issuer
                 String issuerUrl = environment.getProperty(OKTA_OAUTH_PREFIX + "issuer");
                 // if we don't have one just return null
@@ -179,7 +180,7 @@ public class OktaPropertiesMappingEnvironmentPostProcessor implements Environmen
 
         @Override
         public boolean containsProperty(String name) {
-            return "okta.client.orgUrl".equals(name);
+            return "okta.client.org-url".equals(name) || "okta.client.orgUrl".equals(name);
         }
     }
 }

--- a/oauth2/src/main/java/com/okta/spring/oauth/RemappedPropertySource.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/RemappedPropertySource.java
@@ -35,8 +35,8 @@ public class RemappedPropertySource extends EnumerablePropertySource<String> {
     private final Map<String, String> aliasMap = new HashMap<>();
     private final Environment environment;
 
-    public RemappedPropertySource(Map<String, String> aliasMap, Environment environment) {
-        super("okta-to-oauth2");
+    public RemappedPropertySource(String name, Map<String, String> aliasMap, Environment environment) {
+        super(name);
         this.aliasMap.putAll(aliasMap);
         this.environment = environment;
     }

--- a/oauth2/src/test/groovy/com/okta/spring/oauth/OktaPropertiesMappingEnvironmentPostProcessorTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/oauth/OktaPropertiesMappingEnvironmentPostProcessorTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.spring.oauth
+
+import org.springframework.boot.SpringApplication
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.MutablePropertySources
+import org.testng.annotations.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+import static org.mockito.Mockito.*
+
+class OktaPropertiesMappingEnvironmentPostProcessorTest {
+
+    @Test
+    void issuerToOrgTest() {
+
+        def app = mock(SpringApplication)
+        def env = mock(ConfigurableEnvironment)
+        def propertySources = new MutablePropertySources()
+        when(env.getPropertySources()).thenReturn(propertySources)
+        when(env.getProperty("okta.oauth2.issuer")).thenReturn("http://example.com/foo/oauth2/bar")
+                                                   .thenReturn("http://example.com/bar/oauth2/foo")
+        def underTest = new OktaPropertiesMappingEnvironmentPostProcessor()
+        underTest.postProcessEnvironment(env, app)
+        def propSource = propertySources.get("okta-oauth-to-client")
+
+        assertThat propSource.getProperty("okta.client.org-url"), is("http://example.com/foo")
+        assertThat propSource.getProperty("okta.client.org-url"), is("http://example.com/bar")
+    }
+}


### PR DESCRIPTION
Fixes #65