### PR TITLE
Breaking up OktaOAuthCodeFlowConfiguration to support Spring's OAuth2SsoCustomConfiguration

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/oauth/code/OktaOAuthCodeFlowConfiguration.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/code/OktaOAuthCodeFlowConfiguration.java
@@ -17,14 +17,9 @@ package com.okta.spring.oauth.code;
 
 import com.okta.spring.config.OktaOAuth2Properties;
 import com.okta.spring.oauth.OAuth2AccessTokenValidationException;
-import com.okta.spring.oauth.OktaTokenServicesConfig;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2SsoDefaultConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.jwt.crypto.sign.InvalidSignatureException;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
@@ -45,10 +40,7 @@ import org.springframework.security.oauth2.provider.token.TokenStore;
  * @since 0.2.0
  */
 @Configuration
-@AutoConfigureBefore(OAuth2SsoDefaultConfiguration.class)
-@ConditionalOnBean(OAuth2SsoDefaultConfiguration.class)
-@Import(OktaTokenServicesConfig.class)
-public class OktaOAuthCodeFlowConfiguration {
+class OktaOAuthCodeFlowConfiguration {
 
     @Configuration
     @ConditionalOnProperty(name = "okta.oauth2.localTokenValidation", matchIfMissing = true)

--- a/oauth2/src/main/java/com/okta/spring/oauth/code/OktaOAuthCodeFlowCustomConfiguration.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/code/OktaOAuthCodeFlowCustomConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.spring.oauth.code;
+
+
+import com.okta.spring.oauth.OktaTokenServicesConfig;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2SsoCustomConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @since 0.6.0
+ */
+@Configuration
+@AutoConfigureBefore(OAuth2SsoCustomConfiguration.class)
+@ConditionalOnBean(OAuth2SsoCustomConfiguration.class)
+@Import({OktaOAuthCodeFlowConfiguration.class, OktaTokenServicesConfig.class})
+public class OktaOAuthCodeFlowCustomConfiguration {}

--- a/oauth2/src/main/java/com/okta/spring/oauth/code/OktaOAuthCodeFlowDefaultConfiguration.java
+++ b/oauth2/src/main/java/com/okta/spring/oauth/code/OktaOAuthCodeFlowDefaultConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.spring.oauth.code;
+
+
+import com.okta.spring.oauth.OktaTokenServicesConfig;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2SsoDefaultConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @since 0.6.0
+ */
+@Configuration
+@AutoConfigureBefore(OAuth2SsoDefaultConfiguration.class)
+@ConditionalOnBean(OAuth2SsoDefaultConfiguration.class)
+@Import({OktaOAuthCodeFlowConfiguration.class, OktaTokenServicesConfig.class})
+public class OktaOAuthCodeFlowDefaultConfiguration {}

--- a/oauth2/src/main/resources/META-INF/spring.factories
+++ b/oauth2/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration = \
   com.okta.spring.oauth.implicit.ResourceServerConfig,\
-  com.okta.spring.oauth.code.OktaOAuthCodeFlowConfiguration
+  com.okta.spring.oauth.code.OktaOAuthCodeFlowDefaultConfiguration,\
+  com.okta.spring.oauth.code.OktaOAuthCodeFlowCustomConfiguration
 org.springframework.boot.env.EnvironmentPostProcessor=com.okta.spring.oauth.OktaPropertiesMappingEnvironmentPostProcessor

--- a/oauth2/src/test/groovy/com/okta/spring/oauth/code/MockCustomSsoCodeFlowApp.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/oauth/code/MockCustomSsoCodeFlowApp.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.spring.oauth.code
+
+import com.okta.spring.oauth.discovery.OidcDiscoveryMetadata
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+
+@Configuration
+@EnableOAuth2Sso
+@EnableAutoConfiguration
+class MockCustomSsoCodeFlowApp extends WebSecurityConfigurerAdapter {
+
+    @Bean
+    OidcDiscoveryMetadata oktaOidcDiscoveryMetadata() {
+        return new OidcDiscoveryMetadata()
+            .setUserinfoEndpoint("https://okta.example.com/userinfoEndpoint")
+            .setIntrospectionEndpoint("https://okta.example.com/introspectionEndpoint")
+            .setIssuer("https://okta.example.com/oauth2/my_issuer")
+    }
+}

--- a/oauth2/src/test/groovy/com/okta/spring/oauth/code/OktaOAuthCodeFlowCustomConfigurationTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/oauth/code/OktaOAuthCodeFlowCustomConfigurationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Okta, Inc.
+ * Copyright 2018-present Okta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package com.okta.spring.oauth.code
 
-import com.okta.spring.oauth.OktaTokenServicesConfig
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2SsoCustomConfiguration
 import org.springframework.boot.autoconfigure.security.oauth2.resource.AuthoritiesExtractor
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.oauth2.provider.token.TokenStore
@@ -29,18 +29,21 @@ import static org.hamcrest.Matchers.isA
 import static org.hamcrest.Matchers.notNullValue
 
 /**
- * @since 0.2.0
+ * Ensures a Spring Security {@link OAuth2SsoCustomConfiguration} when OktaOAuthCodeFlowCustomConfiguration is used and
+ * a {@link org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter WebSecurityConfigurerAdapter} is found with a @{@link org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso EnableOAuth2Sso}.
+ *
+ * @since 0.6.0
  */
-class OktaOAuthCodeFlowConfigurationTest extends AbstractTestNGSpringContextTests {
+class OktaOAuthCodeFlowCustomConfigurationTest extends AbstractTestNGSpringContextTests {
 
-    @SpringBootTest(classes    = [MockCodeFlowApp, OktaOAuthCodeFlowConfiguration],
+    @SpringBootTest(classes    = [MockCustomSsoCodeFlowApp, OktaOAuthCodeFlowCustomConfiguration],
                     properties = ["okta.oauth2.issuer=https://okta.example.com/oauth2/my_issuer",
                                   "okta.oauth2.discoveryDisabled=true",
                                   "okta.oauth2.localTokenValidation=false"])
     static class RemoteValidationConfigTest extends AbstractTestNGSpringContextTests {
 
         @Autowired
-        OktaTokenServicesConfig oktaTokenServicesConfig
+        OAuth2SsoCustomConfiguration oAuth2SsoCustomConfiguration
 
         @Autowired
         AuthoritiesExtractor authoritiesExtractor
@@ -48,17 +51,17 @@ class OktaOAuthCodeFlowConfigurationTest extends AbstractTestNGSpringContextTest
         @Test
         void theBasics() {
             assertThat authoritiesExtractor, notNullValue()
-            assertThat oktaTokenServicesConfig, notNullValue()
+            assertThat oAuth2SsoCustomConfiguration, notNullValue()
         }
     }
 
-    @SpringBootTest(classes    = [MockCodeFlowApp, OktaOAuthCodeFlowConfiguration],
+    @SpringBootTest(classes    = [MockCustomSsoCodeFlowApp, OktaOAuthCodeFlowCustomConfiguration],
                     properties = ["okta.oauth2.issuer=https://okta.example.com/oauth2/my_issuer",
                                   "okta.oauth2.discoveryDisabled=true"])
     static class LocalValidationConfigTest extends AbstractTestNGSpringContextTests {
 
         @Autowired
-        OktaTokenServicesConfig oktaTokenServicesConfig
+        OAuth2SsoCustomConfiguration oAuth2SsoCustomConfiguration
 
         @Autowired
         TokenStore tokenStore
@@ -66,7 +69,7 @@ class OktaOAuthCodeFlowConfigurationTest extends AbstractTestNGSpringContextTest
         @Test
         void theBasics() {
             assertThat tokenStore, isA(JwkTokenStore)
-            assertThat oktaTokenServicesConfig, notNullValue()
+            assertThat oAuth2SsoCustomConfiguration, notNullValue()
         }
     }
 }

--- a/oauth2/src/test/groovy/com/okta/spring/oauth/code/OktaOAuthCodeFlowDefaultConfigurationTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/oauth/code/OktaOAuthCodeFlowDefaultConfigurationTest.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.spring.oauth.code
+
+import com.okta.spring.oauth.OktaTokenServicesConfig
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.oauth2.resource.AuthoritiesExtractor
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.oauth2.provider.token.TokenStore
+import org.springframework.security.oauth2.provider.token.store.jwk.JwkTokenStore
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests
+import org.testng.annotations.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.isA
+import static org.hamcrest.Matchers.notNullValue
+
+/**
+ * @since 0.2.0
+ */
+class OktaOAuthCodeFlowDefaultConfigurationTest extends AbstractTestNGSpringContextTests {
+
+    @SpringBootTest(classes    = [MockCodeFlowApp, OktaOAuthCodeFlowDefaultConfiguration],
+                    properties = ["okta.oauth2.issuer=https://okta.example.com/oauth2/my_issuer",
+                                  "okta.oauth2.discoveryDisabled=true",
+                                  "okta.oauth2.localTokenValidation=false"])
+    static class RemoteValidationConfigTest extends AbstractTestNGSpringContextTests {
+
+        @Autowired
+        OktaTokenServicesConfig oktaTokenServicesConfig
+
+        @Autowired
+        AuthoritiesExtractor authoritiesExtractor
+
+        @Test
+        void theBasics() {
+            assertThat authoritiesExtractor, notNullValue()
+            assertThat oktaTokenServicesConfig, notNullValue()
+        }
+    }
+
+    @SpringBootTest(classes    = [MockCodeFlowApp, OktaOAuthCodeFlowDefaultConfiguration],
+                    properties = ["okta.oauth2.issuer=https://okta.example.com/oauth2/my_issuer",
+                                  "okta.oauth2.discoveryDisabled=true"])
+    static class LocalValidationConfigTest extends AbstractTestNGSpringContextTests {
+
+        @Autowired
+        OktaTokenServicesConfig oktaTokenServicesConfig
+
+        @Autowired
+        TokenStore tokenStore
+
+        @Test
+        void theBasics() {
+            assertThat tokenStore, isA(JwkTokenStore)
+            assertThat oktaTokenServicesConfig, notNullValue()
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #29 

NOTE: the `custom` version is loaded when you annotate a `WebSecurityConfigurerAdapter` with `@EnableOAuth2Sso`