### PR TITLE
Run CI with JDK 8 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,38 @@
 language: java
+
 jdk:
 - oraclejdk8
+- openjdk11
+
 addons:
   apt:
     packages:
     - libxml2-utils
     - oracle-java8-installer
     - oracle-java8-set-default
+
 before_install:
 - source ./src/ci/before_install.sh
+
+# skip the Travis-CI install phase because Maven handles that directly
 install:
 - "true"
+
 script:
 - "./src/ci/build.sh"
+
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -f okta-spring-security-starter/target/site/jacoco/jacoco.xml
+- bash <(curl -s https://codecov.io/bash) -f okta-spring-security-starter/target/site/jacoco/jacoco.xml
 
 after_failure:
-  - find integration-tests/oauth2/target/failsafe-reports/ -type f | xargs -I{} sh -c 'echo {}; cat {}'
+- find integration-tests/oauth2/target/failsafe-reports/ -type f | xargs -I{} sh -c 'echo {}; cat {}'
 
 deploy:
-  - provider: pages
-    skip_cleanup: true
-    github_token: $GH_API_KEY
-    local_dir: target/gh-pages
-    email: developers@okta.com
-    name: Travis CI - Auto Doc Build
-    on:
-      branch: master
+- provider: pages
+  skip_cleanup: true
+  github_token: $GH_API_KEY
+  local_dir: target/gh-pages
+  email: developers@okta.com
+  name: Travis CI - Auto Doc Build
+  on:
+    branch: master

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>7</version>
+        <version>14</version>
         <relativePath>../okta-java-parent</relativePath>
     </parent>
 
@@ -34,8 +34,8 @@
         <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
         <spring-cloud.version>2.0.2.RELEASE</spring-cloud.version>
         <github.slug>okta/okta-spring-boot</github.slug>
-        <okta.sdk.version>1.3.0</okta.sdk.version>
-        <okta.commons.version>1.1.0</okta.commons.version>
+        <okta.sdk.version>1.4.1</okta.sdk.version>
+        <okta.commons.version>1.1.1</okta.commons.version>
     </properties>
 
     <modules>
@@ -136,7 +136,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.10.0</version>
+                <version>2.24.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
- Updated parent, plugin, and library versions to support Java 11
- minor travis.yml formatting (to match other projects)