### PR TITLE
Updates Web example in readme to use OidcUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ public class ExampleApplication {
     }
 
     @GetMapping("/")
-    public String getMessageOfTheDay(Principal principal) {
-        return principal.getName() + ", this message of the day is boring";
+    public String getMessageOfTheDay((@AuthenticationPrincipal OidcUser user) {
+        return user.getName() + ", this message of the day is boring";
     }
 }
 ```


### PR DESCRIPTION
`@AuthenticationPrincipal OidcUser oidcUser` use instead of `Principal`, which makes it more clear how to get other OIDC info from the principal

Fixes: #76 