### PR TITLE
Add PKCE support

### DIFF
--- a/integration-tests/oauth2-reactive/src/main/java/com/okta/spring/tests/oauth2/reactive/code/ReactiveRedirectCodeFlowApplication.java
+++ b/integration-tests/oauth2-reactive/src/main/java/com/okta/spring/tests/oauth2/reactive/code/ReactiveRedirectCodeFlowApplication.java
@@ -18,12 +18,14 @@ package com.okta.spring.tests.oauth2.reactive.code;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 import java.security.Principal;
 import java.util.Date;
@@ -36,6 +38,18 @@ public class ReactiveRedirectCodeFlowApplication {
     @GetMapping(value = "/")
     public Message getMessageOfTheDay(Principal principal) {
         return new Message("Welcome home, The message of the day is boring: " + principal.getName());
+    }
+
+    @GetMapping("/everyone")
+    @PreAuthorize("hasAuthority('Everyone')")
+    public Mono<String> everyoneAccess(Principal principal) {
+        return Mono.just("Everyone has Access: " + principal.getName());
+    }
+
+    @GetMapping("/invalidGroup")
+    @PreAuthorize("hasAuthority('invalidGroup')")
+    public Mono<String> invalidGroup() {
+        throw new IllegalStateException("Test exception, user should not have access to this method");
     }
 
     @EnableWebFluxSecurity

--- a/integration-tests/oauth2-reactive/src/test/resources/testRunner.yml
+++ b/integration-tests/oauth2-reactive/src/test/resources/testRunner.yml
@@ -57,3 +57,14 @@ scenarios:
     - --server.servlet.session.tracking-modes=cookie
     - --okta.oauth2.postLogoutRedirectUri=/you-are-logged-out
     protectedPath: /oauth2/authorization/okta
+
+  pkce-code-flow-remote-validation:
+    command: com.okta.spring.tests.oauth2.reactive.code.ReactiveRedirectCodeFlowApplication
+    args:
+    - --server.port=${applicationPort}
+    - --okta.oauth2.issuer=https://localhost:${mockHttpsPort}/oauth2/default
+    - --okta.oauth2.clientId=OOICU812
+    - --okta.oauth2.scopes=offline_access
+#    - --okta.oauth2.redirectUri=/authorization-code/callback # not implemented until Spring Sec 5.2
+    - --server.servlet.session.tracking-modes=cookie
+    protectedPath: /oauth2/authorization/okta

--- a/integration-tests/oauth2/src/main/java/com/okta/spring/tests/oauth2/code/BasicRedirectCodeFlowApplication.java
+++ b/integration-tests/oauth2/src/main/java/com/okta/spring/tests/oauth2/code/BasicRedirectCodeFlowApplication.java
@@ -41,6 +41,18 @@ public class BasicRedirectCodeFlowApplication {
         return "Welcome home, The message of the day is boring: " + principal.getName();
     }
 
+    @GetMapping("/everyone")
+    @PreAuthorize("hasAuthority('Everyone')")
+    public String everyoneAccess(Principal principal) {
+        return "Everyone has Access: " + principal.getName();
+    }
+
+    @GetMapping("/invalidGroup")
+    @PreAuthorize("hasAuthority('invalidGroup')")
+    public String invalidGroup() {
+        throw new IllegalStateException("Test exception, user should not have access to this method");
+    }
+
 // The following isn't needed as the equivalent is provided by Spring Boot Security by default
     @Configuration
     static class WebConfig extends WebSecurityConfigurerAdapter {

--- a/integration-tests/oauth2/src/test/resources/testRunner.yml
+++ b/integration-tests/oauth2/src/test/resources/testRunner.yml
@@ -52,3 +52,14 @@ scenarios:
     - --okta.oauth2.postLogoutRedirectUri=/you-are-logged-out
     - --server.servlet.session.tracking-modes=cookie
     protectedPath: /oauth2/authorization/okta
+
+  pkce-code-flow-remote-validation:
+    command: com.okta.spring.tests.oauth2.code.BasicRedirectCodeFlowApplication
+    args:
+    - --server.port=${applicationPort}
+    - --okta.oauth2.issuer=https://localhost:${mockHttpsPort}/oauth2/default
+    - --okta.oauth2.clientId=OOICU812
+    - --okta.oauth2.scopes=offline_access
+    - --okta.oauth2.redirectUri=/authorization-code/callback
+    - --server.servlet.session.tracking-modes=cookie
+    protectedPath: /oauth2/authorization/okta

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/ConditionalOnOktaClientProperties.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/ConditionalOnOktaClientProperties.java
@@ -23,5 +23,5 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
-@ConditionalOnProperty(name = {"spring.security.oauth2.client.registration.okta.client-id", "spring.security.oauth2.client.registration.okta.client-secret"})
+@ConditionalOnProperty(name = {"spring.security.oauth2.client.registration.okta.client-id"})
 @interface ConditionalOnOktaClientProperties {}

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
@@ -53,8 +53,7 @@ final class OktaOAuth2Configurer extends AbstractHttpConfigurer<OktaOAuth2Config
             // if OAuth2ClientProperties bean is not available do NOT configure
             if (!context.getBeansOfType(OAuth2ClientProperties.class).isEmpty()
                 && !isEmpty(oktaOAuth2Properties.getIssuer())
-                && !isEmpty(oktaOAuth2Properties.getClientId())
-                && !isEmpty(oktaOAuth2Properties.getClientSecret())) {
+                && !isEmpty(oktaOAuth2Properties.getClientId())) {
                 // configure Okta user services
                 configureLogin(http, oktaOAuth2Properties);
 

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/UserUtil.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/UserUtil.java
@@ -34,7 +34,7 @@ final class UserUtil {
     static OAuth2User decorateUser(OAuth2User user, OAuth2UserRequest userRequest, String groupClaim) {
 
         // Only post process requests from the "Okta" reg
-        if (!"Okta".equals(userRequest.getClientRegistration().getClientName())) {
+        if (!"okta".equalsIgnoreCase(userRequest.getClientRegistration().getRegistrationId())) {
             return user;
         }
 
@@ -54,7 +54,7 @@ final class UserUtil {
     static OidcUser decorateUser(OidcUser user, OidcUserRequest userRequest, String groupClaim) {
 
         // Only post process requests from the "Okta" reg
-        if (!"Okta".equals(userRequest.getClientRegistration().getClientName())) {
+        if (!"okta".equals(userRequest.getClientRegistration().getRegistrationId())) {
             return user;
         }
 

--- a/oauth2/src/test/groovy/com/okta/spring/boot/oauth/AutoConfigConditionalTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/boot/oauth/AutoConfigConditionalTest.groovy
@@ -202,6 +202,29 @@ class AutoConfigConditionalTest implements HttpMock {
     }
 
     @Test
+    void webLoginConfig_withIssuerAndClientInfo_pkce() {
+
+        webContextRunner().withPropertyValues(
+                "okta.oauth2.issuer=https://test.example.com/",
+                "spring.security.oauth2.client.provider.okta.issuerUri=${mockBaseUrl()}", // work around to not validate the https url
+                "okta.oauth2.client-id=test-client-id")
+            .run { context ->
+            assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2AutoConfig)
+            assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerAutoConfig)
+            assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig)
+            assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ServerHttpServerAutoConfig)
+
+            assertThat(context).hasSingleBean(OktaOAuth2ResourceServerAutoConfig)
+            assertThat(context).hasSingleBean(JwtDecoder)
+            assertThat(context).hasSingleBean(OAuth2ClientProperties)
+            assertThat(context).hasSingleBean(OktaOAuth2Properties)
+            assertThat(context).hasSingleBean(OktaOAuth2AutoConfig)
+
+            assertFiltersEnabled(context, OAuth2LoginAuthenticationFilter, BearerTokenAuthenticationFilter)
+        }
+    }
+
+    @Test
     void reactiveResourceServerTest_emptyProperties() {
 
         // missing properties, component does not load
@@ -277,6 +300,32 @@ class AutoConfigConditionalTest implements HttpMock {
                 "spring.security.oauth2.client.provider.okta.issuerUri=${mockBaseUrl()}", // work around to not validate the https url
                 "okta.oauth2.client-id=test-client-id",
                 "okta.oauth2.client-secret=test-client-secret")
+            .run { context ->
+
+            assertThat(context).doesNotHaveBean(OktaOAuth2ResourceServerAutoConfig)
+            assertThat(context).doesNotHaveBean(JwtDecoder)
+            assertThat(context).doesNotHaveBean(OktaOAuth2AutoConfig)
+
+            assertThat(context).hasSingleBean(ReactiveOktaOAuth2AutoConfig)
+            assertThat(context).hasSingleBean(ReactiveOktaOAuth2ResourceServerAutoConfig)
+            assertThat(context).hasSingleBean(ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig)
+            assertThat(context).hasSingleBean(ReactiveOktaOAuth2ServerHttpServerAutoConfig)
+
+            assertThat(context).hasSingleBean(OAuth2ClientProperties)
+            assertThat(context).hasSingleBean(OktaOAuth2Properties)
+
+            assertWebFiltersEnabled(context, OAuth2LoginAuthenticationWebFilter, AuthenticationWebFilter)
+            assertJwtBearerWebFilterEnabled(context)
+        }
+    }
+
+    @Test
+    void reactiveLoginConfig_withIssuerAndClientInfo_pkce() {
+
+        reactiveContextRunner().withPropertyValues(
+                "okta.oauth2.issuer=https://test.example.com/",
+                "spring.security.oauth2.client.provider.okta.issuerUri=${mockBaseUrl()}", // work around to not validate the https url
+                "okta.oauth2.client-id=test-client-id")
             .run { context ->
 
             assertThat(context).doesNotHaveBean(OktaOAuth2ResourceServerAutoConfig)

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.2.RELEASE</spring-boot.version>
         <spring-cloud.version>2.1.2.RELEASE</spring-cloud.version>
         <github.slug>okta/okta-spring-boot</github.slug>
         <okta.sdk.version>1.5.2</okta.sdk.version>
@@ -118,7 +118,7 @@
             <dependency>
                 <groupId>com.okta.oidc.tck</groupId>
                 <artifactId>okta-oidc-tck</artifactId>
-                <version>0.5.4</version>
+                <version>0.5.5</version>
             </dependency>
 
             <!-- Dependency overrides for transitive dependencies with CVEs -->


### PR DESCRIPTION
ITs to support PCKE have already been added to okta-oidc-tck (and will run automatically now that it is configured in testRunner.yml)

TL;DR: client-secret is no longer required