### PR TITLE
Define and use OAuth2UserService beans

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
@@ -17,15 +17,21 @@ package com.okta.spring.boot.oauth;
 
 import com.okta.spring.boot.oauth.config.OktaOAuth2Properties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.net.URI;
 
@@ -43,5 +49,17 @@ class OktaOAuth2AutoConfig {
         OidcClientInitiatedLogoutSuccessHandler successHandler = new OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository);
         successHandler.setPostLogoutRedirectUri(URI.create(oktaOAuth2Properties.getPostLogoutRedirectUri()));
         return successHandler;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name="oAuth2UserService")
+    OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService(OktaOAuth2Properties oktaOAuth2Properties) {
+        return new OktaOAuth2UserService(oktaOAuth2Properties.getGroupsClaim());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name="oidcUserService")
+    OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService(OktaOAuth2Properties oktaOAuth2Properties) {
+        return new OktaOidcUserService(oktaOAuth2Properties.getGroupsClaim());
     }
 }

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
@@ -84,10 +84,6 @@ final class OktaOAuth2Configurer extends AbstractHttpConfigurer<OktaOAuth2Config
     private void configureLogin(HttpSecurity http, OktaOAuth2Properties oktaOAuth2Properties) throws Exception {
 
         http.oauth2Login()
-                .userInfoEndpoint()
-                .userService(new OktaOAuth2UserService(oktaOAuth2Properties.getGroupsClaim()))
-                .oidcUserService(new OktaOidcUserService(oktaOAuth2Properties.getGroupsClaim()))
-            .and()
                 .tokenEndpoint()
                     .accessTokenResponseClient(accessTokenResponseClient());
 

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2AutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2AutoConfig.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -43,11 +44,13 @@ import reactor.core.publisher.Flux;
 class ReactiveOktaOAuth2AutoConfig {
 
     @Bean
+    @ConditionalOnMissingBean
     ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService(OktaOAuth2Properties oktaOAuth2Properties) {
         return new ReactiveOktaOAuth2UserService(oktaOAuth2Properties.getGroupsClaim());
     }
 
     @Bean
+    @ConditionalOnMissingBean
     OidcReactiveOAuth2UserService oidcUserService(OktaOAuth2Properties oktaOAuth2Properties,
                                                   @Qualifier("oauth2UserService") ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService) {
         return new ReactiveOktaOidcUserService(oktaOAuth2Properties.getGroupsClaim(), oAuth2UserService);


### PR DESCRIPTION
Previously we used an AbstractHttpConfigurer to set the Okta implementation of the OAuth2UserService (and oidc user service)
This made replacing Okta impl impossible to replace due to how/when those impls were configured.
Now they loaded automatically.

Fixes: #136