### PR TITLE
Typo in Spring placeholder syntax

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessor.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessor.java
@@ -123,7 +123,7 @@ final class OktaOAuth2PropertiesMappingEnvironmentPostProcessor implements Envir
 
     private PropertySource oktaRedirectUriPropertySource(Environment environment) {
         Map<String, Object> properties = new HashMap<>();
-        properties.put("spring.security.oauth2.client.registration.okta.redirect-uri", "{baseUrl}${okta.oauth2.redirect-uri}");
+        properties.put("spring.security.oauth2.client.registration.okta.redirect-uri", "${baseUrl}${okta.oauth2.redirect-uri}");
         return new ConditionalMapPropertySource("okta-redirect-uri-helper", properties, environment, "okta.oauth2.redirect-uri");
     }
 


### PR DESCRIPTION
When resource server is located behind reverse proxy, redirect_uri parameter in the request, which the resource server sends to OKTA authorization server, contains invalid base URL.