### PR TITLE
Add note in readme about the orgUrl property

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ To integrate the [Okta Java SDK](https://github.com/okta/okta-sdk-java) into you
 
 Then define the following properties:
 
-|| key || description ||
-------------------------
+| Key | Description |
+------|--------------
 | `okta.client.orgUrl` | Your Okta Url: `https://{yourOktaDomain}`, i.e. `https://dev-123456.okta.com` |
 | `okta.client.token` | An Okta API token, see [creating an API token](https://developer.okta.com/docs/api/getting_started/getting_a_token) for more info. |
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,13 @@ To integrate the [Okta Java SDK](https://github.com/okta/okta-sdk-java) into you
 </dependency>
 ```
 
-Then define the `okta.client.token` property. See [creating an API token](https://developer.okta.com/docs/api/getting_started/getting_a_token) for more info.
+Then define the following properties:
+
+|| key || description ||
+------------------------
+| `okta.client.orgUrl` | Your Okta Url: `https://{yourOktaDomain}`, i.e. `https://dev-123456.okta.com` |
+| `okta.client.token` | An Okta API token, see [creating an API token](https://developer.okta.com/docs/api/getting_started/getting_a_token) for more info. |
+
 
 All that is left is to inject the client (`com.okta.sdk.client.Client`)! Take a look at [this post](https://spring.io/blog/2007/07/11/setter-injection-versus-constructor-injection-and-the-use-of-required/) for more info on the best way to inject your beans.
 


### PR DESCRIPTION
In older versions, this property was resolved automatically but caused a few edge cases.
Users can reduce duplication by doing something like:
```properties
okta.client.orgUrl=https://dev-123456.okta.com
okta.oauth2.issuer=${okta.client.orgUrl}/oauth2/default
```