### PR TITLE
Update to Spring Boot 2.4.0

### DIFF
--- a/integration-tests/oauth2-reactive/pom.xml
+++ b/integration-tests/oauth2-reactive/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/integration-tests/oauth2-reactive/src/test/resources/testRunner.yml
+++ b/integration-tests/oauth2-reactive/src/test/resources/testRunner.yml
@@ -67,4 +67,5 @@ scenarios:
     - --okta.oauth2.scopes=offline_access
 #    - --okta.oauth2.redirectUri=/authorization-code/callback # not implemented until Spring Sec 5.2
     - --server.servlet.session.tracking-modes=cookie
+    - --spring.security.oauth2.client.registration.okta.client-authentication-method=none
     protectedPath: /oauth2/authorization/okta

--- a/integration-tests/oauth2-reactive/src/test/resources/testRunner.yml
+++ b/integration-tests/oauth2-reactive/src/test/resources/testRunner.yml
@@ -52,7 +52,6 @@ scenarios:
     - --okta.oauth2.issuer=https://localhost:${mockHttpsPort}/oauth2/default
     - --okta.oauth2.clientId=OOICU812
     - --okta.oauth2.clientSecret=VERY_SECRET
-    - --okta.oauth2.scopes=profile,email,openid
 #    - --okta.oauth2.redirectUri=/authorization-code/callback # not implemented until Spring Sec 5.2
     - --server.servlet.session.tracking-modes=cookie
     - --okta.oauth2.postLogoutRedirectUri=/you-are-logged-out
@@ -67,5 +66,4 @@ scenarios:
     - --okta.oauth2.scopes=offline_access
 #    - --okta.oauth2.redirectUri=/authorization-code/callback # not implemented until Spring Sec 5.2
     - --server.servlet.session.tracking-modes=cookie
-    - --spring.security.oauth2.client.registration.okta.client-authentication-method=none
     protectedPath: /oauth2/authorization/okta

--- a/integration-tests/oauth2/pom.xml
+++ b/integration-tests/oauth2/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/integration-tests/oauth2/src/test/resources/testRunner.yml
+++ b/integration-tests/oauth2/src/test/resources/testRunner.yml
@@ -47,7 +47,6 @@ scenarios:
     - --okta.oauth2.issuer=https://localhost:${mockHttpsPort}/oauth2/default
     - --okta.oauth2.clientId=OOICU812
     - --okta.oauth2.clientSecret=VERY_SECRET
-    - --okta.oauth2.scopes=profile,email,openid
     - --okta.oauth2.redirectUri=/authorization-code/callback
     - --okta.oauth2.postLogoutRedirectUri=/you-are-logged-out
     - --server.servlet.session.tracking-modes=cookie
@@ -62,5 +61,4 @@ scenarios:
     - --okta.oauth2.scopes=offline_access
     - --okta.oauth2.redirectUri=/authorization-code/callback
     - --server.servlet.session.tracking-modes=cookie
-    - --spring.security.oauth2.client.registration.okta.client-authentication-method=none
     protectedPath: /oauth2/authorization/okta

--- a/integration-tests/oauth2/src/test/resources/testRunner.yml
+++ b/integration-tests/oauth2/src/test/resources/testRunner.yml
@@ -62,4 +62,5 @@ scenarios:
     - --okta.oauth2.scopes=offline_access
     - --okta.oauth2.redirectUri=/authorization-code/callback
     - --server.servlet.session.tracking-modes=cookie
+    - --spring.security.oauth2.client.registration.okta.client-authentication-method=none
     protectedPath: /oauth2/authorization/okta

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
@@ -25,7 +25,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
@@ -83,12 +82,13 @@ class OktaOAuth2AutoConfig {
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnDefaultWebSecurity
     static class OAuth2SecurityFilterChainConfiguration {
+
         @Bean
         SecurityFilterChain oauth2SecurityFilterChain(HttpSecurity http) throws Exception {
             // as of Spring Security 5.4 the default chain uses oauth2Login OR a JWT resource server (NOT both)
             // this does the same as both defaults merged together (and provides the previous behavior)
             http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
-            http.oauth2Login(Customizer.withDefaults());
+            http.oauth2Login();
             http.oauth2Client();
             http.oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
             return http.build();

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
@@ -37,6 +37,8 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
 import java.net.URI;
@@ -69,6 +71,13 @@ class OktaOAuth2AutoConfig {
     @ConditionalOnMissingBean(name="oidcUserService")
     OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService(Collection<AuthoritiesProvider> authoritiesProviders) {
         return new OktaOidcUserService(oAuth2UserService(authoritiesProviders), authoritiesProviders);
+    }
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter(OktaOAuth2Properties oktaOAuth2Properties) {
+        OktaJwtAuthenticationConverter converter = new OktaJwtAuthenticationConverter(oktaOAuth2Properties.getGroupsClaim());
+        converter.setJwtGrantedAuthoritiesConverter(new JwtGrantedAuthoritiesConverter());
+        return converter;
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
@@ -20,11 +20,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.security.ConditionalOnDefaultWebSecurity;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -33,6 +37,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.SecurityFilterChain;
 
 import java.net.URI;
 import java.util.Collection;
@@ -64,5 +69,20 @@ class OktaOAuth2AutoConfig {
     @ConditionalOnMissingBean(name="oidcUserService")
     OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService(Collection<AuthoritiesProvider> authoritiesProviders) {
         return new OktaOidcUserService(oAuth2UserService(authoritiesProviders), authoritiesProviders);
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnDefaultWebSecurity
+    static class OAuth2SecurityFilterChainConfiguration {
+        @Bean
+        SecurityFilterChain oauth2SecurityFilterChain(HttpSecurity http) throws Exception {
+            // as of Spring Security 5.4 the default chain uses oauth2Login OR a JWT resource server (NOT both)
+            // this does the same as both defaults merged together (and provides the previous behavior)
+            http.authorizeRequests((requests) -> requests.anyRequest().authenticated());
+            http.oauth2Login(Customizer.withDefaults());
+            http.oauth2Client();
+            http.oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
+            return http.build();
+        }
     }
 }

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
@@ -20,7 +20,6 @@ import com.okta.spring.boot.oauth.http.UserAgentRequestInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -65,19 +64,6 @@ final class OktaOAuth2Configurer extends AbstractHttpConfigurer<OktaOAuth2Config
             } else {
                 log.debug("OAuth/OIDC Login not configured due to missing issuer, client-id, or client-secret property");
             }
-
-            // resource server configuration
-            if (!context.getBeansOfType(OAuth2ResourceServerProperties.class).isEmpty()) {
-                OAuth2ResourceServerProperties resourceServerProperties = context.getBean(OAuth2ResourceServerProperties.class);
-                if (!isEmpty(resourceServerProperties.getJwt().getIssuerUri())) {
-                    // configure Okta specific auth converter (extracts authorities from `groupsClaim`
-                    configureResourceServer(http, oktaOAuth2Properties);
-                } else {
-                    log.debug("OAuth resource server not configured due to missing issuer property");
-                }
-            } else {
-                log.debug("OAuth resource server not configured due to missing OAuth2ResourceServerProperties bean");
-            }
         }
     }
 
@@ -90,12 +76,6 @@ final class OktaOAuth2Configurer extends AbstractHttpConfigurer<OktaOAuth2Config
         if (oktaOAuth2Properties.getRedirectUri() != null) {
             http.oauth2Login().redirectionEndpoint().baseUri(oktaOAuth2Properties.getRedirectUri());
         }
-    }
-
-    private void configureResourceServer(HttpSecurity http, OktaOAuth2Properties oktaOAuth2Properties) throws Exception {
-
-        http.oauth2ResourceServer()
-                .jwt().jwtAuthenticationConverter(new OktaJwtAuthenticationConverter(oktaOAuth2Properties.getGroupsClaim()));
     }
 
     private OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient() {

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2ResourceServerAutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2ResourceServerAutoConfig.java
@@ -27,9 +27,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -45,13 +44,14 @@ class OktaOAuth2ResourceServerAutoConfig {
     JwtDecoder jwtDecoder(OAuth2ResourceServerProperties oAuth2ResourceServerProperties,
                           OktaOAuth2Properties oktaOAuth2Properties) {
 
-            NimbusJwtDecoderJwkSupport decoder = new NimbusJwtDecoderJwkSupport(oAuth2ResourceServerProperties.getJwt().getJwkSetUri());
-            decoder.setJwtValidator(TokenUtil.jwtValidator(oAuth2ResourceServerProperties.getJwt().getIssuerUri(), oktaOAuth2Properties.getAudience()));
-            decoder.setRestOperations(restOperations());
-            return decoder;
+        NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder builder = NimbusJwtDecoder.withJwkSetUri(oAuth2ResourceServerProperties.getJwt().getJwkSetUri());
+        builder.restOperations(restTemplate());
+        NimbusJwtDecoder decoder = builder.build();
+        decoder.setJwtValidator(TokenUtil.jwtValidator(oktaOAuth2Properties.getIssuer(), oktaOAuth2Properties.getAudience()));
+        return decoder;
     }
 
-    private RestOperations restOperations() {
+    private RestTemplate restTemplate() {
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.getInterceptors().add(new UserAgentRequestInterceptor());
         return restTemplate;

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2AutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2AutoConfig.java
@@ -17,33 +17,36 @@ package com.okta.spring.boot.oauth;
 
 import com.okta.spring.boot.oauth.config.OktaOAuth2Properties;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcReactiveOAuth2UserService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
 import reactor.core.publisher.Flux;
 
 import java.util.Collection;
 
 @Configuration
-@AutoConfigureAfter(ReactiveSecurityAutoConfiguration.class)
+@AutoConfigureBefore(name = {
+    "org.springframework.boot.autoconfigure.security.oauth2.client.reactive.ReactiveOAuth2ClientAutoConfiguration",
+    "org.springframework.boot.autoconfigure.security.oauth2.resource.reactive.ReactiveOAuth2ResourceServerAutoConfiguration"})
 @EnableConfigurationProperties(OktaOAuth2Properties.class)
 @ConditionalOnOktaClientProperties
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
 @ConditionalOnClass({ Flux.class, EnableWebFluxSecurity.class, ClientRegistration.class })
-@ConditionalOnBean(ReactiveSecurityAutoConfiguration.class)
 @Import(AuthorityProvidersConfig.class)
 class ReactiveOktaOAuth2AutoConfig {
 
@@ -58,5 +61,22 @@ class ReactiveOktaOAuth2AutoConfig {
     OidcReactiveOAuth2UserService oidcUserService(Collection<AuthoritiesProvider> authoritiesProviders,
                                                   @Qualifier("oauth2UserService") ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService) {
         return new ReactiveOktaOidcUserService(authoritiesProviders, oAuth2UserService);
+    }
+
+    @Bean
+    @ConditionalOnBean(ReactiveJwtDecoder.class)
+    @ConditionalOnMissingBean(SecurityWebFilterChain.class)
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http, ReactiveJwtDecoder jwtDecoder) {
+        // as of Spring Security 5.4 the default chain uses oauth2Login OR a JWT resource server (NOT both)
+        // this does the same as both defaults merged together (and provides the previous behavior)
+        http.authorizeExchange().anyExchange().authenticated();
+        http.oauth2Login();
+        http.oauth2Client();
+        http.oauth2ResourceServer((server) -> customDecoder(server, jwtDecoder));
+        return http.build();
+    }
+
+    private void customDecoder(ServerHttpSecurity.OAuth2ResourceServerSpec server, ReactiveJwtDecoder decoder) {
+        server.jwt((jwt) -> jwt.jwtDecoder(decoder));
     }
 }

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/config/OktaOAuth2Properties.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/config/OktaOAuth2Properties.java
@@ -22,11 +22,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
+import java.util.HashSet;
 
 @ConfigurationProperties("okta.oauth2")
 public final class OktaOAuth2Properties implements Validator {
+
+    public static final Set<String> DEFAULT_SCOPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("email", "openid", "profile")));
 
     private final OAuth2ClientProperties clientProperties;
 
@@ -54,7 +59,7 @@ public final class OktaOAuth2Properties implements Validator {
     /**
      * Authorization scopes.
      */
-    private Set<String> scopes;
+    private Set<String> scopes = DEFAULT_SCOPES;
 
     /**
      * Expected access token audience claim value.

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/config/OktaOAuth2Properties.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/config/OktaOAuth2Properties.java
@@ -22,16 +22,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
-import java.util.HashSet;
 
 @ConfigurationProperties("okta.oauth2")
 public final class OktaOAuth2Properties implements Validator {
-
-    public static final Set<String> DEFAULT_SCOPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("email", "openid", "profile")));
 
     private final OAuth2ClientProperties clientProperties;
 
@@ -59,7 +54,7 @@ public final class OktaOAuth2Properties implements Validator {
     /**
      * Authorization scopes.
      */
-    private Set<String> scopes = DEFAULT_SCOPES;
+    private Set<String> scopes;
 
     /**
      * Expected access token audience claim value.

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,11 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
-        <spring-cloud.version>2.2.4.RELEASE</spring-cloud.version>
+        <spring-boot.version>2.4.0</spring-boot.version>
+        <spring-cloud.version>2.2.6.RELEASE</spring-cloud.version>
         <github.slug>okta/okta-spring-boot</github.slug>
         <okta.sdk.version>1.6.0</okta.sdk.version>
-        <okta.commons.version>1.2.3</okta.commons.version>
+        <okta.commons.version>1.2.4</okta.commons.version>
     </properties>
 
     <modules>
@@ -118,14 +118,7 @@
             <dependency>
                 <groupId>com.okta.oidc.tck</groupId>
                 <artifactId>okta-oidc-tck</artifactId>
-                <version>0.5.5</version>
-            </dependency>
-
-            <!-- Dependency overrides for transitive dependencies with CVEs -->
-            <dependency>
-                <groupId>com.nimbusds</groupId>
-                <artifactId>nimbus-jose-jwt</artifactId>
-                <version>7.9</version>
+                <version>0.5.6</version>
             </dependency>
 
             <!-- test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -141,3 +141,4 @@
         </dependencies>
     </dependencyManagement>
 </project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>14</version>
+        <version>18</version>
         <relativePath>../okta-java-parent</relativePath>
     </parent>
 
@@ -147,16 +147,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <version>5.2.2</version> <!-- TODO: bump the version in the parent pom -->
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>

--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -132,4 +132,12 @@
         <cve>CVE-2019-0232</cve>
     </suppress>
 
+    <!-- wrong product, invalid artifact match -->
+    <suppress>
+        <notes><![CDATA[ file name: oauth2-oidc-sdk-8.23.1.jar ]]></notes>
+        <gav regex="true">^com\.nimbusds:oauth2\-oidc\-sdk:.*$</gav>
+        <cve>CVE-2007-1651</cve>
+        <cve>CVE-2007-1652</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
A few things change in Spring Security 5.4 (used by Spring Boot 2.4)

1. The default WebSecurityAdapter (or equivalent, now configures a "login" or a "resource server", not both by default
  - this change restores that functionality
2. PKCE for unauthenticated clients looks to be NOT configured by default 
  - though I might be missing something there, open question to the Spring Security team on Gitter
3. Default OAuth scopes are NO longer set by Spring Security
  - this change restores that functionality, setting them to the previous default of: `openid, profile, email`
4. It's now easier to set the JWT converter, you can just inject it!
5. Minor test changes (we have tests that poke at the internals of spring sec, these often need to change when implementation details change)