### PR TITLE
Prep for minor version release 1.5.0

### DIFF
--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-coverage</artifactId>

--- a/examples/config-server/pom.xml
+++ b/examples/config-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring.examples</groupId>
         <artifactId>okta-spring-boot-examples</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-cloud-config-example</artifactId>

--- a/examples/hosted-login-code-flow/pom.xml
+++ b/examples/hosted-login-code-flow/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring.examples</groupId>
         <artifactId>okta-spring-boot-examples</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-hosted-code-flow-example</artifactId>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-sdk</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.5.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.okta.spring.examples</groupId>

--- a/examples/redirect-code-flow/pom.xml
+++ b/examples/redirect-code-flow/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring.examples</groupId>
         <artifactId>okta-spring-boot-examples</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-redirect-code-flow-example</artifactId>

--- a/examples/siw-jquery/pom.xml
+++ b/examples/siw-jquery/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring.examples</groupId>
         <artifactId>okta-spring-boot-examples</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-siw-jquery-example</artifactId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.5.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Other standard Spring starters -->

--- a/examples/webflux-resource-server/pom.xml
+++ b/examples/webflux-resource-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring.examples</groupId>
         <artifactId>okta-spring-boot-examples</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-webflux-example</artifactId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>1.5.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Other standard Spring starters -->

--- a/integration-tests/oauth2-reactive/pom.xml
+++ b/integration-tests/oauth2-reactive/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/integration-tests/oauth2/pom.xml
+++ b/integration-tests/oauth2/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-security-oauth2</artifactId>

--- a/okta-spring-boot-starter/pom.xml
+++ b/okta-spring-boot-starter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.okta.spring</groupId>
     <artifactId>okta-spring-boot-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <name>Okta Spring Boot</name>
     <packaging>pom</packaging>
 
@@ -71,23 +71,23 @@
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-starter</artifactId>
-                <version>1.4.1-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-security-oauth2</artifactId>
-                <version>1.4.1-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-sdk</artifactId>
-                <version>1.4.1-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-integration-tests-oauth2</artifactId>
-                <version>1.4.1-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
@@ -118,7 +118,7 @@
             <dependency>
                 <groupId>com.okta.oidc.tck</groupId>
                 <artifactId>okta-oidc-tck</artifactId>
-                <version>0.5.6</version>
+                <version>0.5.7</version>
             </dependency>
 
             <!-- test dependencies -->

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-sdk</artifactId>


### PR DESCRIPTION
Set version to `1.5.0-SNAPSHOT` and thereby prep for minor version `1.5.0` release (current release version is the wild is 1.4.0).

` mvn versions:set -DnewVersion=1.5.0-SNAPSHOT` was run to achieve this.

Also bumped up `okta-oidc-tck` version from `0.5.6` to `0.5.7`.