### PR TITLE
Move JwtAuthenticationCoverter to the ResourceServerAuthConfig class

### DIFF
--- a/integration-tests/oauth2-reactive/src/test/resources/testRunner.yml
+++ b/integration-tests/oauth2-reactive/src/test/resources/testRunner.yml
@@ -35,7 +35,7 @@ scenarios:
     args:
     - --server.port=${applicationPort}
     - --okta.oauth2.issuer=https://localhost:${mockHttpsPort}/oauth2/default
-    - --okta.oauth2.clientId=OOICU812
+    # A client ID is NOT required, #218
     - --server.session.trackingModes=cookie
     - --debug
 

--- a/integration-tests/oauth2/src/test/resources/testRunner.yml
+++ b/integration-tests/oauth2/src/test/resources/testRunner.yml
@@ -34,7 +34,7 @@ scenarios:
     args:
     - --server.port=${applicationPort}
     - --okta.oauth2.issuer=https://localhost:${mockHttpsPort}/oauth2/default
-    - --okta.oauth2.clientId=OOICU812
+    # A client ID is NOT required, #218
     - --server.session.trackingModes=cookie
 
   oidc-code-flow-local-validation:

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
@@ -36,8 +36,6 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
-import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
 import java.net.URI;
@@ -70,13 +68,6 @@ class OktaOAuth2AutoConfig {
     @ConditionalOnMissingBean(name="oidcUserService")
     OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService(Collection<AuthoritiesProvider> authoritiesProviders) {
         return new OktaOidcUserService(oAuth2UserService(authoritiesProviders), authoritiesProviders);
-    }
-
-    @Bean
-    public JwtAuthenticationConverter jwtAuthenticationConverter(OktaOAuth2Properties oktaOAuth2Properties) {
-        OktaJwtAuthenticationConverter converter = new OktaJwtAuthenticationConverter(oktaOAuth2Properties.getGroupsClaim());
-        converter.setJwtGrantedAuthoritiesConverter(new JwtGrantedAuthoritiesConverter());
-        return converter;
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2ResourceServerAutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2ResourceServerAutoConfig.java
@@ -28,7 +28,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -38,6 +40,13 @@ import org.springframework.web.client.RestTemplate;
 @EnableConfigurationProperties(OktaOAuth2Properties.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 class OktaOAuth2ResourceServerAutoConfig {
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter(OktaOAuth2Properties oktaOAuth2Properties) {
+        OktaJwtAuthenticationConverter converter = new OktaJwtAuthenticationConverter(oktaOAuth2Properties.getGroupsClaim());
+        converter.setJwtGrantedAuthoritiesConverter(new JwtGrantedAuthoritiesConverter());
+        return converter;
+    }
 
     @Bean
     @ConditionalOnMissingBean

--- a/oauth2/src/test/groovy/com/okta/spring/boot/oauth/AutoConfigConditionalTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/boot/oauth/AutoConfigConditionalTest.groovy
@@ -63,6 +63,7 @@ import org.springframework.security.oauth2.client.web.server.authentication.OAut
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
 import org.springframework.security.oauth2.server.resource.authentication.JwtReactiveAuthenticationManager
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter
 import org.springframework.security.web.FilterChainProxy
@@ -162,6 +163,7 @@ class AutoConfigConditionalTest implements HttpMock {
             .run {context ->
                 assertThat(context).hasSingleBean(OktaOAuth2ResourceServerAutoConfig)
                 assertThat(context).hasSingleBean(JwtDecoder)
+                assertThat(context).hasSingleBean(OktaJwtAuthenticationConverter)
                 assertThat(context).doesNotHaveBean(OktaOAuth2AutoConfig)
                 assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2AutoConfig)
                 assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerAutoConfig)
@@ -217,6 +219,7 @@ class AutoConfigConditionalTest implements HttpMock {
 
             assertThat(context).hasSingleBean(OktaOAuth2ResourceServerAutoConfig)
             assertThat(context).hasSingleBean(JwtDecoder)
+            assertThat(context).hasSingleBean(OktaJwtAuthenticationConverter)
             assertThat(context).hasSingleBean(OAuth2ClientProperties)
             assertThat(context).hasSingleBean(OktaOAuth2Properties)
             assertThat(context).hasSingleBean(OktaOAuth2AutoConfig)
@@ -245,6 +248,7 @@ class AutoConfigConditionalTest implements HttpMock {
 
             assertThat(context).hasSingleBean(OktaOAuth2ResourceServerAutoConfig)
             assertThat(context).hasSingleBean(JwtDecoder)
+            assertThat(context).hasSingleBean(OktaJwtAuthenticationConverter)
             assertThat(context).hasSingleBean(OAuth2ClientProperties)
             assertThat(context).hasSingleBean(OktaOAuth2Properties)
             assertThat(context).hasSingleBean(OktaOAuth2AutoConfig)


### PR DESCRIPTION
The previous release had the OktaJwtAuthenticationCoverter nested in the OktaOAuthAutoConfig, which adds a conditional on the `client-id` property which is NOT needed for the JWT converter
This change moves this converter to its correct location in the OktaResourceServerAuthConfig, UTs not check for this bean, and the corresponding ITs are now run WITHOUT the client-id property

Fixes: #218