### PR TITLE
[WIP - DO NOT MERGE] - Validate okta.oauth2.issuer during startup

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessor.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessor.java
@@ -15,7 +15,6 @@
  */
 package com.okta.spring.boot.oauth.env;
 
-import com.okta.commons.lang.Assert;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
@@ -98,7 +97,6 @@ final class OktaOAuth2PropertiesMappingEnvironmentPostProcessor implements Envir
         // default scopes, as of Spring Security 5.4 default scopes are no longer added, this restores that functionality
         environment.getPropertySources().addLast(defaultOktaScopesSource(environment));
         // okta's endpoints can be resolved from an issuer
-        Assert.isTrue(environment.containsProperty(OKTA_OAUTH_ISSUER), OKTA_OAUTH_ISSUER + " cannot be empty");
         environment.getPropertySources().addLast(oktaStaticDiscoveryPropertySource(environment));
         environment.getPropertySources().addLast(oktaRedirectUriPropertySource(environment));
         environment.getPropertySources().addLast(otkaForcePkcePropertySource(environment));
@@ -156,7 +154,7 @@ final class OktaOAuth2PropertiesMappingEnvironmentPostProcessor implements Envir
         properties.put("spring.security.oauth2.client.provider.okta.jwk-set-uri", "${okta.oauth2.issuer}/v1/keys");
         properties.put("spring.security.oauth2.client.provider.okta.issuer-uri", "${okta.oauth2.issuer}"); // required for OIDC logout
 
-        return new ConditionalMapPropertySource("okta-static-discovery", properties, environment, OKTA_OAUTH_ISSUER);
+        return new ConditionalMapPropertySource("okta-static-discovery", properties, environment);
     }
 
     @Override

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessor.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessor.java
@@ -15,6 +15,7 @@
  */
 package com.okta.spring.boot.oauth.env;
 
+import com.okta.commons.lang.Assert;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
@@ -97,6 +98,7 @@ final class OktaOAuth2PropertiesMappingEnvironmentPostProcessor implements Envir
         // default scopes, as of Spring Security 5.4 default scopes are no longer added, this restores that functionality
         environment.getPropertySources().addLast(defaultOktaScopesSource(environment));
         // okta's endpoints can be resolved from an issuer
+        Assert.isTrue(environment.containsProperty(OKTA_OAUTH_ISSUER), OKTA_OAUTH_ISSUER + " cannot be empty");
         environment.getPropertySources().addLast(oktaStaticDiscoveryPropertySource(environment));
         environment.getPropertySources().addLast(oktaRedirectUriPropertySource(environment));
         environment.getPropertySources().addLast(otkaForcePkcePropertySource(environment));

--- a/oauth2/src/test/groovy/com/okta/spring/boot/oauth/AutoConfigConditionalTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/boot/oauth/AutoConfigConditionalTest.groovy
@@ -140,17 +140,19 @@ class AutoConfigConditionalTest implements HttpMock {
         // missing properties, component does not load
         webContextRunner()
             .run { context ->
-                assertThat(context).doesNotHaveBean(OktaOAuth2ResourceServerAutoConfig)
-                assertThat(context).doesNotHaveBean(JwtDecoder)
-                assertThat(context).doesNotHaveBean(OktaOAuth2AutoConfig)
-                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2AutoConfig)
-                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerAutoConfig)
-                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig)
-                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ServerHttpServerAutoConfig)
-                assertThat(context).doesNotHaveBean(OAuth2AuthorizedClientService)
-                assertThat(context).doesNotHaveBean(AuthoritiesProvider)
+                assertThat(context).getFailure().hasCauseInstanceOf(IllegalArgumentException.class)
 
-                assertFiltersDisabled(context, OAuth2LoginAuthenticationFilter, BearerTokenAuthenticationFilter)
+//                assertThat(context).doesNotHaveBean(OktaOAuth2ResourceServerAutoConfig)
+//                assertThat(context).doesNotHaveBean(JwtDecoder)
+//                assertThat(context).doesNotHaveBean(OktaOAuth2AutoConfig)
+//                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2AutoConfig)
+//                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerAutoConfig)
+//                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig)
+//                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ServerHttpServerAutoConfig)
+//                assertThat(context).doesNotHaveBean(OAuth2AuthorizedClientService)
+//                assertThat(context).doesNotHaveBean(AuthoritiesProvider)
+//
+//                assertFiltersDisabled(context, OAuth2LoginAuthenticationFilter, BearerTokenAuthenticationFilter)
         }
     }
 
@@ -264,18 +266,20 @@ class AutoConfigConditionalTest implements HttpMock {
         // missing properties, component does not load
         reactiveContextRunner()
             .run { context ->
-                assertThat(context).doesNotHaveBean(OktaOAuth2ResourceServerAutoConfig)
-                assertThat(context).doesNotHaveBean(JwtDecoder)
-                assertThat(context).doesNotHaveBean(OktaOAuth2AutoConfig)
-                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2AutoConfig)
-                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerAutoConfig)
-                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig)
-                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ServerHttpServerAutoConfig)
-                assertThat(context).doesNotHaveBean(OAuth2AuthorizedClientService)
-                assertThat(context).doesNotHaveBean(AuthoritiesProvider)
+                assertThat(context).getFailure().hasCauseInstanceOf(IllegalArgumentException.class)
 
-                assertWebFiltersDisabled(context, OAuth2LoginAuthenticationWebFilter)
-                assertWebFiltersDisabled(context, ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter)
+//                assertThat(context).doesNotHaveBean(OktaOAuth2ResourceServerAutoConfig)
+//                assertThat(context).doesNotHaveBean(JwtDecoder)
+//                assertThat(context).doesNotHaveBean(OktaOAuth2AutoConfig)
+//                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2AutoConfig)
+//                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerAutoConfig)
+//                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig)
+//                assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2ServerHttpServerAutoConfig)
+//                assertThat(context).doesNotHaveBean(OAuth2AuthorizedClientService)
+//                assertThat(context).doesNotHaveBean(AuthoritiesProvider)
+//
+//                assertWebFiltersDisabled(context, OAuth2LoginAuthenticationWebFilter)
+//                assertWebFiltersDisabled(context, ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter)
         }
     }
 

--- a/oauth2/src/test/groovy/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessorTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessorTest.groovy
@@ -18,9 +18,11 @@ package com.okta.spring.boot.oauth.env
 import org.springframework.core.env.Environment
 import org.springframework.core.env.MapPropertySource
 import org.springframework.mock.env.MockEnvironment
+import org.testng.Assert
 import org.testng.annotations.Test
 
 import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.is
 import static org.hamcrest.Matchers.nullValue
 
@@ -63,12 +65,21 @@ class OktaOAuth2PropertiesMappingEnvironmentPostProcessorTest {
         assertThat environment.getProperty(CLIENT_ID), nullValue()
         assertThat environment.getProperty(CLIENT_SECRET), nullValue()
         assertThat environment.getProperty(SCOPE, Set), nullValue()
-        assertThat environment.getProperty(ISSUER), nullValue()
-        assertThat environment.getProperty(RS_KEYS_URI), nullValue()
-        assertThat environment.getProperty(AUTHZ_URI), nullValue()
-        assertThat environment.getProperty(TOKEN_URI), nullValue()
-        assertThat environment.getProperty(USER_INFO_URI), nullValue()
-        assertThat environment.getProperty(PROVIDER_KEYS_URI), nullValue()
+
+        try {
+            environment.getProperty(ISSUER)
+            environment.getProperty(RS_KEYS_URI)
+            environment.getProperty(AUTHZ_URI)
+            environment.getProperty(TOKEN_URI)
+            environment.getProperty(USER_INFO_URI)
+            environment.getProperty(PROVIDER_KEYS_URI)
+
+            Assert.fail("Expected IllegalArgumentException")
+        } catch (IllegalArgumentException e) {
+            assertThat(e.message, containsString("Could not resolve placeholder 'okta.oauth2.issuer'"))
+        }
+
+
     }
 
     private Environment buildAndProcessEnvironment(Map<String, Object> properties) {


### PR DESCRIPTION
Server will not start if `okta.oauth2.issuer` is not set.

Startup will fail with below error trace if user does not supply `okta.oauth2.issuer` property:

```
Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2020-12-08 23:12:14.101 ERROR 30559 --- [           main] o.s.boot.SpringApplication               : Application run failed

org.springframework.beans.factory.BeanDefinitionStoreException: Failed to process import candidates for configuration class [com.okta.spring.example.ResourceServerExampleApplication]; nested exception is java.lang.IllegalStateException: Error processing condition on com.okta.spring.boot.oauth.OktaOAuth2ResourceServerAutoConfig
	at org.springframework.context.annotation.ConfigurationClassParser.processImports(ConfigurationClassParser.java:610) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.annotation.ConfigurationClassParser.access$800(ConfigurationClassParser.java:111) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.annotation.ConfigurationClassParser$DeferredImportSelectorGroupingHandler.lambda$processGroupImports$1(ConfigurationClassParser.java:812) ~[spring-context-5.3.1.jar:5.3.1]
	at java.util.ArrayList.forEach(ArrayList.java:1257) ~[na:1.8.0_222]
	at org.springframework.context.annotation.ConfigurationClassParser$DeferredImportSelectorGroupingHandler.processGroupImports(ConfigurationClassParser.java:809) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.annotation.ConfigurationClassParser$DeferredImportSelectorHandler.process(ConfigurationClassParser.java:780) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:193) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.processConfigBeanDefinitions(ConfigurationClassPostProcessor.java:336) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.postProcessBeanDefinitionRegistry(ConfigurationClassPostProcessor.java:252) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanDefinitionRegistryPostProcessors(PostProcessorRegistrationDelegate.java:285) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:99) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:751) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:569) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:144) ~[spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:767) [spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:759) [spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:426) [spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:326) [spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1309) [spring-boot-2.4.0.jar:2.4.0]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1298) [spring-boot-2.4.0.jar:2.4.0]
	at com.okta.spring.example.ResourceServerExampleApplication.main(ResourceServerExampleApplication.java:26) [classes/:na]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_222]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_222]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_222]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_222]
	at org.springframework.boot.maven.AbstractRunMojo$LaunchRunner.run(AbstractRunMojo.java:578) [spring-boot-maven-plugin-2.4.0.jar:2.4.0]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_222]
Caused by: java.lang.IllegalStateException: Error processing condition on com.okta.spring.boot.oauth.OktaOAuth2ResourceServerAutoConfig
	at org.springframework.boot.autoconfigure.condition.SpringBootCondition.matches(SpringBootCondition.java:60) ~[spring-boot-autoconfigure-2.4.0.jar:2.4.0]
	at org.springframework.context.annotation.ConditionEvaluator.shouldSkip(ConditionEvaluator.java:108) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.annotation.ConfigurationClassParser.processConfigurationClass(ConfigurationClassParser.java:226) ~[spring-context-5.3.1.jar:5.3.1]
	at org.springframework.context.annotation.ConfigurationClassParser.processImports(ConfigurationClassParser.java:600) ~[spring-context-5.3.1.jar:5.3.1]
	... 26 common frames omitted
Caused by: java.lang.IllegalArgumentException: Could not resolve placeholder 'okta.oauth2.issuer' in value "${okta.oauth2.issuer}/v1/keys"
	at org.springframework.util.PropertyPlaceholderHelper.parseStringValue(PropertyPlaceholderHelper.java:178) ~[spring-core-5.3.1.jar:5.3.1]
	at org.springframework.util.PropertyPlaceholderHelper.replacePlaceholders(PropertyPlaceholderHelper.java:124) ~[spring-core-5.3.1.jar:5.3.1]
	at org.springframework.core.env.AbstractPropertyResolver.doResolvePlaceholders(AbstractPropertyResolver.java:239) ~[spring-core-5.3.1.jar:5.3.1]
	at org.springframework.core.env.AbstractPropertyResolver.resolveRequiredPlaceholders(AbstractPropertyResolver.java:210) ~[spring-core-5.3.1.jar:5.3.1]
	at org.springframework.core.env.AbstractPropertyResolver.resolveNestedPlaceholders(AbstractPropertyResolver.java:230) ~[spring-core-5.3.1.jar:5.3.1]
	at org.springframework.core.env.PropertySourcesPropertyResolver.getProperty(PropertySourcesPropertyResolver.java:88) ~[spring-core-5.3.1.jar:5.3.1]
	at org.springframework.core.env.PropertySourcesPropertyResolver.getProperty(PropertySourcesPropertyResolver.java:62) ~[spring-core-5.3.1.jar:5.3.1]
	at org.springframework.core.env.AbstractEnvironment.getProperty(AbstractEnvironment.java:535) ~[spring-core-5.3.1.jar:5.3.1]
	at org.springframework.boot.autoconfigure.condition.OnPropertyCondition$Spec.collectProperties(OnPropertyCondition.java:140) ~[spring-boot-autoconfigure-2.4.0.jar:2.4.0]
	at org.springframework.boot.autoconfigure.condition.OnPropertyCondition$Spec.access$000(OnPropertyCondition.java:105) ~[spring-boot-autoconfigure-2.4.0.jar:2.4.0]
	at org.springframework.boot.autoconfigure.condition.OnPropertyCondition.determineOutcome(OnPropertyCondition.java:91) ~[spring-boot-autoconfigure-2.4.0.jar:2.4.0]
	at org.springframework.boot.autoconfigure.condition.OnPropertyCondition.getMatchOutcome(OnPropertyCondition.java:55) ~[spring-boot-autoconfigure-2.4.0.jar:2.4.0]
	at org.springframework.boot.autoconfigure.condition.SpringBootCondition.matches(SpringBootCondition.java:47) ~[spring-boot-autoconfigure-2.4.0.jar:2.4.0]
	... 29 common frames omitted

```