### PR TITLE
address cve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.10.0</version>
+                <version>2.12.0</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -132,6 +132,12 @@
         <cve>CVE-2019-0232</cve>
     </suppress>
 
+    <suppress>
+        <notes><![CDATA[ file name: tomcat-embed-core-9.0.39.jar ]]></notes>
+        <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed-.*:.*$</gav>
+        <cve>CVE-2020-17527</cve>
+    </suppress>
+
     <!-- wrong product, invalid artifact match -->
     <suppress>
         <notes><![CDATA[ file name: oauth2-oidc-sdk-8.23.1.jar ]]></notes>


### PR DESCRIPTION
Address below CVEs:

1. ` jackson-databind-2.10.0.jar (pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.10.0, cpe:2.3:a:fasterxml:jackson:2.10.0:*:*:*:*:*:*:*, cpe:2.3:a:fasterxml:jackson-databind:2.10.0:*:*:*:*:*:*:*) : CVE-2020-25649`

2. `tomcat-embed-core-9.0.39.jar (pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39, cpe:2.3:a:apache:tomcat:9.0.39:*:*:*:*:*:*:*, cpe:2.3:a:apache_software_foundation:tomcat:9.0.39:*:*:*:*:*:*:*, cpe:2.3:a:apache_tomcat:apache_tomcat:9.0.39:*:*:*:*:*:*:*) : CVE-2020-17527`
