### PR TITLE
Testing build with Spring Boot 2.5.1

### DIFF
--- a/integration-tests/oauth2-reactive-spring/src/test/resources/testRunner.yml
+++ b/integration-tests/oauth2-reactive-spring/src/test/resources/testRunner.yml
@@ -21,7 +21,6 @@ scenarios:
     command: com.okta.spring.tests.common.reactive.code.ReactiveRedirectCodeFlowApplication
     args:
       - --server.port=${applicationPort}
-      - --spring.security.oauth2.resourceserver.jwt.issuer-uri=https://localhost:${mockHttpsPort}/oauth2/default
       - --spring.security.oauth2.client.provider.okta.authorization-uri=https://localhost:${mockHttpsPort}/oauth2/default/v1/authorize
       - --spring.security.oauth2.client.provider.okta.issuer-uri=https://localhost:${mockHttpsPort}/oauth2/default
       - --spring.security.oauth2.client.registration.okta.client-id=OOICU812
@@ -68,7 +67,6 @@ scenarios:
     args:
       - --server.port=${applicationPort}
       - --server.servlet.session.tracking-modes=cookie
-      - --spring.security.oauth2.resourceserver.jwt.issuer-uri=https://localhost:${mockHttpsPort}/oauth2/default
       - --spring.security.oauth2.client.provider.okta.authorization-uri=https://localhost:${mockHttpsPort}/oauth2/default/v1/authorize
       - --spring.security.oauth2.client.provider.okta.issuer-uri=https://localhost:${mockHttpsPort}/oauth2/default
       - --spring.security.oauth2.client.registration.okta.client-id=OOICU812

--- a/integration-tests/oauth2-servlet-spring/src/test/resources/testRunner.yml
+++ b/integration-tests/oauth2-servlet-spring/src/test/resources/testRunner.yml
@@ -21,7 +21,6 @@ scenarios:
     command: com.okta.spring.tests.common.servlet.code.BasicRedirectCodeFlowApplication
     args:
       - --server.port=${applicationPort}
-      - --spring.security.oauth2.resourceserver.jwt.issuer-uri=https://localhost:${mockHttpsPort}/oauth2/default
       - --spring.security.oauth2.client.provider.okta.authorization-uri=https://localhost:${mockHttpsPort}/oauth2/default/v1/authorize
       - --spring.security.oauth2.client.provider.okta.issuer-uri=https://localhost:${mockHttpsPort}/oauth2/default
       - --spring.security.oauth2.client.registration.okta.client-id=OOICU812
@@ -74,7 +73,6 @@ scenarios:
     args:
       - --server.port=${applicationPort}
       - --server.servlet.session.tracking-modes=cookie
-      - --spring.security.oauth2.resourceserver.jwt.issuer-uri=https://localhost:${mockHttpsPort}/oauth2/default
       - --spring.security.oauth2.client.provider.okta.authorization-uri=https://localhost:${mockHttpsPort}/oauth2/default/v1/authorize
       - --spring.security.oauth2.client.provider.okta.issuer-uri=https://localhost:${mockHttpsPort}/oauth2/default
       - --spring.security.oauth2.client.registration.okta.client-id=OOICU812

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
@@ -88,9 +88,9 @@ final class OktaOAuth2Configurer extends AbstractHttpConfigurer<OktaOAuth2Config
                     log.debug("Opaque Token configurer is set in OAuth resource server configuration. " +
                         "Opaque Token validation/introspection will be configured.");
                     configureResourceServerForOpaqueTokenValidation(http, oktaOAuth2Properties);
-                } else {
-                    log.debug("Defaulting to Okta JWT resource server configuration.");
-                    configureResourceServerForJwtValidation(http, oktaOAuth2Properties);
+                }
+                else {
+                    log.debug("OAuth2ResourceServerConfigurer bean not configured, Resource Server support will not be enabled.");
                 }
             } else {
                 log.debug("OAuth/OIDC Login not configured due to missing issuer, client-id, or client-secret property");

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessor.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessor.java
@@ -254,7 +254,7 @@ final class OktaOAuth2PropertiesMappingEnvironmentPostProcessor implements Envir
 
             // only support this key
             if (OKTA_OAUTH_ISSUER_WITH_PATH.equals(key)) {
-                // issuer could be null
+                // issuer could be null (only resolve properties after checking if the key is `OKTA_OAUTH_ISSUER_WITH_PATH`)
                 return Optional.ofNullable(environment.getProperty(OKTA_OAUTH_ISSUER))
                     .map(issuer -> {
                         // Check if URL is a Okta Org Authorization Server

--- a/oauth2/src/test/groovy/com/okta/spring/boot/oauth/AutoConfigConditionalTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/boot/oauth/AutoConfigConditionalTest.groovy
@@ -452,7 +452,6 @@ class AutoConfigConditionalTest implements HttpMock {
                 assertThat(context).doesNotHaveBean(AuthoritiesProvider)
 
                 assertWebFiltersDisabled(context, OAuth2LoginAuthenticationWebFilter)
-                assertWebFiltersDisabled(context, ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter)
             }
     }
 
@@ -476,7 +475,7 @@ class AutoConfigConditionalTest implements HttpMock {
                 assertThat(context).hasSingleBean(ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig)
 
                 assertWebFiltersDisabled(context, OAuth2LoginAuthenticationWebFilter)
-                assertWebFiltersEnabled(context, ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter)
+                assertWebFiltersEnabled(context, AuthenticationWebFilter)
                 assertJwtBearerWebFilterEnabled(context)
             }
     }
@@ -501,7 +500,7 @@ class AutoConfigConditionalTest implements HttpMock {
             assertThat(context).hasSingleBean(OAuth2ClientProperties)
             assertThat(context).hasSingleBean(OktaOAuth2Properties)
 
-            assertWebFiltersEnabled(context, ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter)
+            assertWebFiltersEnabled(context, AuthenticationWebFilter)
             assertJwtBearerWebFilterEnabled(context)
         }
     }
@@ -529,7 +528,7 @@ class AutoConfigConditionalTest implements HttpMock {
                 assertThat(context).hasSingleBean(OktaOAuth2Properties)
                 assertThat(context).getBeans(AuthoritiesProvider).containsOnlyKeys("tokenScopesAuthoritiesProvider", "groupClaimsAuthoritiesProvider")
 
-                assertWebFiltersEnabled(context, OAuth2LoginAuthenticationWebFilter, ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter)
+                assertWebFiltersEnabled(context, AuthenticationWebFilter)
                 assertJwtBearerWebFilterEnabled(context)
             }
     }
@@ -559,7 +558,7 @@ class AutoConfigConditionalTest implements HttpMock {
                 assertThat(context).hasSingleBean(OktaOAuth2Properties)
                 assertThat(context).getBeans(AuthoritiesProvider).containsOnlyKeys("tokenScopesAuthoritiesProvider", "groupClaimsAuthoritiesProvider")
 
-                assertWebFiltersEnabled(context, OAuth2LoginAuthenticationWebFilter, ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter)
+                assertWebFiltersEnabled(context, OAuth2LoginAuthenticationWebFilter, AuthenticationWebFilter)
                 assertJwtBearerWebFilterEnabled(context)
         }
     }
@@ -588,7 +587,7 @@ class AutoConfigConditionalTest implements HttpMock {
             assertThat(context).hasSingleBean(OktaOAuth2Properties)
             assertThat(context).getBeans(AuthoritiesProvider).containsOnlyKeys("tokenScopesAuthoritiesProvider", "groupClaimsAuthoritiesProvider")
 
-            assertWebFiltersEnabled(context, OAuth2LoginAuthenticationWebFilter, ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter)
+            assertWebFiltersEnabled(context, OAuth2LoginAuthenticationWebFilter, AuthenticationWebFilter)
             assertJwtBearerWebFilterEnabled(context)
         }
     }
@@ -649,7 +648,7 @@ class AutoConfigConditionalTest implements HttpMock {
                 assertThat(context).doesNotHaveBean(ReactiveOktaOAuth2UserService)
                 assertThat(context).doesNotHaveBean(ReactiveOktaOidcUserService)
 
-                assertWebFiltersEnabled(context, OAuth2LoginAuthenticationWebFilter, ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter)
+                assertWebFiltersEnabled(context, OAuth2LoginAuthenticationWebFilter, AuthenticationWebFilter)
                 assertJwtBearerWebFilterEnabled(context)
             }
     }
@@ -676,7 +675,7 @@ class AutoConfigConditionalTest implements HttpMock {
 
     private static Stream<WebFilter> activeJwtAuthenticationWebFilters(ApplicationContext context) {
         return activeWebFilters(context).stream()
-                        .filter { it.getClass() == ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter }
+                        .filter { it.getClass() == AuthenticationWebFilter }
                         .map {(AuthenticationWebFilter) it}
                         .filter {
                             // here be dragons
@@ -691,8 +690,9 @@ class AutoConfigConditionalTest implements HttpMock {
     static void assertFilterConfiguredWithJwtAuthenticationManager(ApplicationContext context) {
         MatcherSecurityWebFilterChain filterChain = (MatcherSecurityWebFilterChain) context.getBean(BeanIds.SPRING_SECURITY_FILTER_CHAIN)
         Stream<WebFilter> filters = filterChain.getWebFilters().toStream()
-        AuthenticationWebFilter webFilter = (AuthenticationWebFilter) filters
-            .filter { (it.getClass().name == ServerHttpSecurity.OAuth2ResourceServerSpec.BearerTokenAuthenticationWebFilter.name) }
+        AuthenticationWebFilter webFilter = filters
+            .filter { (it.getClass().name == AuthenticationWebFilter.name) }
+            .map {(AuthenticationWebFilter) it}
             .findFirst()
             .orElseThrow { new TestException("Failed to find BearerTokenAuthenticationWebFilter configured for JWTs, this could be caused by a configuration error, or a change in Spring Security (internal APIs are used to discover this WebFilter)")}
         ReactiveAuthenticationManagerResolver<?> authenticationManagerResolver = (ReactiveAuthenticationManagerResolver<?>) ReflectionTestUtils

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring-boot.version>2.5.0</spring-boot.version>
+        <spring-boot.version>2.5.1</spring-boot.version>
         <spring-cloud.version>3.0.4</spring-cloud.version>
         <github.slug>okta/okta-spring-boot</github.slug>
         <okta.sdk.version>4.0.0</okta.sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring-boot.version>2.4.4</spring-boot.version>
+        <spring-boot.version>2.5.0</spring-boot.version>
         <spring-cloud.version>3.0.4</spring-cloud.version>
         <github.slug>okta/okta-spring-boot</github.slug>
         <okta.sdk.version>4.0.0</okta.sdk.version>
@@ -166,8 +166,23 @@
             <dependency>
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
-                <version>3.0.7</version>
+                <version>3.2.0</version>
             </dependency>
+            <!-- TODO: these deps should be removed, they are here temporarily to fix a dependency resolution issue
+                 the okta-oidc-tck pulls in 3.2.0 and something else pulls in a later version causing a runtime issue
+                 Next time Spring or rest-assured is updated, try to remove the following deps.
+             -->
+            <dependency>
+                <groupId>io.rest-assured</groupId>
+                <artifactId>json-path</artifactId>
+                <version>3.2.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.rest-assured</groupId>
+                <artifactId>xml-path</artifactId>
+                <version>3.2.0</version>
+            </dependency>
+            <!-- end rest-assured dep fix -->
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>


### PR DESCRIPTION
Fixes: #280

From commits:

Update to Spring Boot 2.5

    With 2.5 a JwtDecoder bean is now initialized when `spring.security.oauth2.resourceserver.jwt.issuer-uri` is set.  There were a few invalid test assumptions that were setting this property (likely a copypasta eror)
    For example the OAuth Code Flow ITs check to make sure requests to the /keys endpoint is NOT called (not needed for non OIDC or jwt resource server usage).

    Another fix with a fragile test which detects the internal configuration of Spring Security.

    OktaOAuth2Configurer had an unused else block, which caused a problem with 2.5 when a resource server was not configured.


