### PR TITLE
clean Spring Boot Version Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This library uses semantic versioning and follows Okta's [library version policy
 | Version | Status                    |
 | ------- | ------------------------- |
 | 0.x.x | :warning: Retired |
-| 1.x.0 | :clock9: Retiring effective September 28, 2021 |
-| 2.x.0 | :heavy_check_mark: Stable |
+| 1.x.x | :clock9: Retiring effective September 28, 2021 |
+| 2.x.x | :heavy_check_mark: Stable |
 
 ## Spring Boot Version Compatibility
 


### PR DESCRIPTION
having the 0 hardcoded in 2.x.0 is kind of confusing when current version is actually 2.0.1