### PR TITLE
Add exclusion fro hibernate-validator in owasp-suppression

### DIFF
--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -36,4 +36,15 @@
         <cve>CVE-2012-5055</cve>
     </suppress>
 
+    <!-- false positive, this CVE was fixed in 6.1.5 per:
+         https://in.relation.to/2020/05/07/hibernate-validator-615-6020-released/
+         And the release notes for 6.2.0 make reference to that post/fix:
+         https://in.relation.to/2021/01/06/hibernate-validator-700-62-final-released/
+         -->
+    <suppress>
+        <notes><![CDATA[ file name: spring-security-rsa-1.0.9.RELEASE.jar ]]></notes>
+        <gav regex="true">^org\.hibernate\.validator:hibernate-validator:6\.2.*$</gav>
+        <cve>CVE-2020-10693</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
This CVE was fixed in 6.1.5 per: https://in.relation.to/2020/05/07/hibernate-validator-615-6020-released/
And the release notes for 6.2.0 make reference to that post/fix: https://in.relation.to/2021/01/06/hibernate-validator-700-62-final-released/