### PR TITLE
Remove Jackson dep version override in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>19</version>
+        <version>21</version>
         <relativePath>../okta-java-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,6 @@
         <dependencies>
 
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>2.12.4</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,12 @@
 
             <!-- test dependencies -->
             <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>7.0.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.github.tomakehurst</groupId>
                 <artifactId>wiremock-standalone</artifactId>
                 <version>2.27.2</version>


### PR DESCRIPTION
- Fixes #308 
- Remove Jackson version override in pom
- Update to Java parent v21