### PR TITLE
Obvious Fix the NoUniqueBeanDefinitionException when get Environment bean

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
@@ -62,7 +62,7 @@ final class OktaOAuth2Configurer extends AbstractHttpConfigurer<OktaOAuth2Config
                 && !isEmpty(propertiesProvider.getIssuerUri())
                 && !isEmpty(propertiesRegistration.getClientId())) {
                 // configure Okta user services
-                configureLogin(http, oktaOAuth2Properties, context.getBean(Environment.class));
+                configureLogin(http, oktaOAuth2Properties, context.getEnvironment());
 
                 // check for RP-Initiated logout
                 if (!context.getBeansOfType(OidcClientInitiatedLogoutSuccessHandler.class).isEmpty()) {


### PR DESCRIPTION
Obvious Fix：
Fix the occurrence of NoUniqueBeanDefinitionException when there are multiple `org.springframework.core.env.Environment` instance bean during `OktaOAuth2Configurer.init()` to call `context.getBean(Class<T> requiredType)` where only class type as needed. More details see #445  