### PR TITLE
Use Jakarta package for servlet-api

### DIFF
--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -28,9 +28,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
spring-boot-dependencies uses this dep
(NOTE: this will work with both javax and jakarta packages depending on the version of spring used)
