### PR TITLE
Migrate spring auto config away from spring.factories

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2AutoConfig.java
@@ -17,6 +17,7 @@ package com.okta.spring.boot.oauth;
 
 import com.okta.spring.boot.oauth.config.OktaOAuth2Properties;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -41,7 +42,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.Collection;
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnOktaClientProperties
 @EnableConfigurationProperties(OktaOAuth2Properties.class)
 @ConditionalOnClass({ EnableWebSecurity.class, ClientRegistration.class })

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2ResourceServerAutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2ResourceServerAutoConfig.java
@@ -18,6 +18,7 @@ package com.okta.spring.boot.oauth;
 import com.okta.commons.lang.Strings;
 import com.okta.spring.boot.oauth.config.OktaOAuth2Properties;
 import com.okta.spring.boot.oauth.http.UserAgentRequestInterceptor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -27,7 +28,6 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.O
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.client.support.BasicAuthenticationInterceptor;
 import org.springframework.http.converter.FormHttpMessageConverter;
@@ -52,7 +52,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
-@Configuration
+@AutoConfiguration
 @AutoConfigureBefore(OAuth2ResourceServerAutoConfiguration.class)
 @ConditionalOnClass(JwtAuthenticationToken.class)
 @ConditionalOnOktaResourceServerProperties

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2AutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2AutoConfig.java
@@ -17,6 +17,7 @@ package com.okta.spring.boot.oauth;
 
 import com.okta.spring.boot.oauth.config.OktaOAuth2Properties;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -24,7 +25,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -40,7 +40,7 @@ import reactor.core.publisher.Flux;
 
 import java.util.Collection;
 
-@Configuration
+@AutoConfiguration
 @AutoConfigureBefore(name = {
     "org.springframework.boot.autoconfigure.security.oauth2.client.reactive.ReactiveOAuth2ClientAutoConfiguration",
     "org.springframework.boot.autoconfigure.security.oauth2.resource.reactive.ReactiveOAuth2ResourceServerAutoConfiguration"})

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2ResourceServerAutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2ResourceServerAutoConfig.java
@@ -16,6 +16,7 @@
 package com.okta.spring.boot.oauth;
 
 import com.okta.spring.boot.oauth.config.OktaOAuth2Properties;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -24,14 +25,13 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2Res
 import org.springframework.boot.autoconfigure.security.oauth2.resource.reactive.ReactiveOAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
 import org.springframework.web.reactive.function.client.WebClient;
 
-@Configuration
+@AutoConfiguration
 @AutoConfigureBefore(ReactiveOAuth2ResourceServerAutoConfiguration.class)
 @ConditionalOnOktaResourceServerProperties
 @EnableConfigurationProperties({OktaOAuth2Properties.class, OAuth2ResourceServerProperties.class})

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig.java
@@ -17,20 +17,20 @@ package com.okta.spring.boot.oauth;
 
 import com.okta.spring.boot.oauth.config.OktaOAuth2Properties;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnOktaResourceServerProperties
 @AutoConfigureAfter(ReactiveOktaOAuth2ResourceServerAutoConfig.class)
 @EnableConfigurationProperties({OktaOAuth2Properties.class, OAuth2ResourceServerProperties.class})

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2ServerHttpServerAutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2ServerHttpServerAutoConfig.java
@@ -20,6 +20,7 @@ import com.okta.spring.boot.oauth.config.OktaOAuth2Properties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -27,7 +28,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.DelegatingReactiveAuthenticationManager;
@@ -54,7 +54,7 @@ import reactor.core.publisher.Mono;
 
 import java.net.URISyntaxException;
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnOktaClientProperties
 @AutoConfigureAfter(ReactiveOktaOAuth2AutoConfig.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)

--- a/oauth2/src/main/resources/META-INF/spring.factories
+++ b/oauth2/src/main/resources/META-INF/spring.factories
@@ -1,10 +1,3 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration = \
-  com.okta.spring.boot.oauth.OktaOAuth2AutoConfig,\
-  com.okta.spring.boot.oauth.OktaOAuth2ResourceServerAutoConfig,\
-  com.okta.spring.boot.oauth.ReactiveOktaOAuth2AutoConfig,\
-  com.okta.spring.boot.oauth.ReactiveOktaOAuth2ResourceServerAutoConfig,\
-  com.okta.spring.boot.oauth.ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig,\
-  com.okta.spring.boot.oauth.ReactiveOktaOAuth2ServerHttpServerAutoConfig
 org.springframework.boot.env.EnvironmentPostProcessor = com.okta.spring.boot.oauth.env.OktaOAuth2PropertiesMappingEnvironmentPostProcessor
 org.springframework.context.ApplicationListener = com.okta.spring.boot.oauth.env.OktaEnvironmentPostProcessorApplicationListener
 

--- a/oauth2/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/oauth2/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,6 @@
+com.okta.spring.boot.oauth.OktaOAuth2AutoConfig
+com.okta.spring.boot.oauth.OktaOAuth2ResourceServerAutoConfig
+com.okta.spring.boot.oauth.ReactiveOktaOAuth2AutoConfig
+com.okta.spring.boot.oauth.ReactiveOktaOAuth2ResourceServerAutoConfig
+com.okta.spring.boot.oauth.ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig
+com.okta.spring.boot.oauth.ReactiveOktaOAuth2ServerHttpServerAutoConfig

--- a/sdk/src/main/java/com/okta/spring/boot/sdk/OktaSdkConfig.java
+++ b/sdk/src/main/java/com/okta/spring/boot/sdk/OktaSdkConfig.java
@@ -28,6 +28,7 @@ import com.okta.sdk.client.Clients;
 import com.okta.spring.boot.sdk.cache.SpringCacheManager;
 import com.okta.spring.boot.sdk.config.OktaClientProperties;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -36,7 +37,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 import static com.okta.commons.configcheck.ConfigurationValidator.validateApiToken;
@@ -47,7 +47,7 @@ import static com.okta.commons.configcheck.ConfigurationValidator.validateOrgUrl
  *
  * @since 0.3.0
  */
-@Configuration
+@AutoConfiguration
 @Conditional(OktaSdkConfig.OktaApiConditions.class)
 @ConditionalOnClass(Client.class)
 @EnableConfigurationProperties(OktaClientProperties.class)

--- a/sdk/src/main/resources/META-INF/spring.factories
+++ b/sdk/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration = com.okta.spring.boot.sdk.OktaSdkConfig
-
 org.springframework.boot.env.EnvironmentPostProcessor = com.okta.spring.boot.sdk.env.OktaSdkPropertiesEnvironmentPostProcessor

--- a/sdk/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sdk/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.okta.spring.boot.sdk.OktaSdkConfig


### PR DESCRIPTION
Support for auto config classes in spring.factories has been removed in v3. AutoConfiguration.imports must be used now (and can be used after 2.7)
See: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#new-autoconfiguration-annotation
