### PR TITLE
Update to newer JwtGrantedAuthoritiesConverter API

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaJwtAuthenticationConverter.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaJwtAuthenticationConverter.java
@@ -16,26 +16,19 @@
 package com.okta.spring.boot.oauth;
 
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 
 import java.util.Collection;
-import java.util.HashSet;
 
 final class OktaJwtAuthenticationConverter extends JwtAuthenticationConverter {
 
-    private final String groupClaim;
-
     public OktaJwtAuthenticationConverter(String groupClaim) {
-        this.groupClaim = groupClaim;
-    }
-
-    @Override
-    protected Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
-
-        Collection<GrantedAuthority> result = new HashSet<>(super.extractAuthorities(jwt));
-        result.addAll(TokenUtil.tokenClaimsToAuthorities(jwt.getClaims(), groupClaim));
-
-        return result;
+        JwtGrantedAuthoritiesConverter originalConverter = new JwtGrantedAuthoritiesConverter();
+        this.setJwtGrantedAuthoritiesConverter(source -> {
+            Collection<GrantedAuthority> result = originalConverter.convert(source);
+            result.addAll(TokenUtil.tokenClaimsToAuthorities(source.getClaims(), groupClaim));
+            return result;
+        });
     }
 }

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2ResourceServerAutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2ResourceServerAutoConfig.java
@@ -40,7 +40,6 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.oauth2.server.resource.introspection.NimbusOpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.web.client.RestTemplate;
@@ -62,9 +61,7 @@ class OktaOAuth2ResourceServerAutoConfig {
 
     @Bean
     public JwtAuthenticationConverter jwtAuthenticationConverter(OktaOAuth2Properties oktaOAuth2Properties) {
-        OktaJwtAuthenticationConverter converter = new OktaJwtAuthenticationConverter(oktaOAuth2Properties.getGroupsClaim());
-        converter.setJwtGrantedAuthoritiesConverter(new JwtGrantedAuthoritiesConverter());
-        return converter;
+        return new OktaJwtAuthenticationConverter(oktaOAuth2Properties.getGroupsClaim());
     }
 
     @Bean

--- a/oauth2/src/test/groovy/com/okta/spring/boot/oauth/OktaJwtAuthenticationConverterTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/boot/oauth/OktaJwtAuthenticationConverterTest.groovy
@@ -36,7 +36,7 @@ class OktaJwtAuthenticationConverterTest {
                 myGroups: ["g1", "g2"]
         ])
 
-        def authorities = new OktaJwtAuthenticationConverter("myGroups").extractAuthorities(jwt)
+        def authorities = new OktaJwtAuthenticationConverter("myGroups").convert(jwt).getAuthorities()
         assertThat authorities, hasItems(
                 new SimpleGrantedAuthority("SCOPE_one"),
                 new SimpleGrantedAuthority("SCOPE_two"),
@@ -49,7 +49,7 @@ class OktaJwtAuthenticationConverterTest {
     void extractAuthorities_emptyTest() {
         def jwt = new Jwt("foo", Instant.now(), Instant.now().plusMillis(1000L), [simple: "value"], [simple: "value"]) // these maps must not be empty
 
-        def authorities = new OktaJwtAuthenticationConverter("myGroups").extractAuthorities(jwt)
+        def authorities = new OktaJwtAuthenticationConverter("myGroups").convert(jwt).getAuthorities()
         assertThat authorities, hasSize(0)
     }
 }


### PR DESCRIPTION
The previous usage of `extractAuthorities()`, is deprecated and was removed in Spring Boot v3 (Spring Sec v6)
