### PR TITLE
oauth2: from javax to jakarta

### DIFF
--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -40,9 +40,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
         </dependency>
 
         <!-- Okta deps -->

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessor.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/env/OktaOAuth2PropertiesMappingEnvironmentPostProcessor.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * This {@link EnvironmentPostProcessor} configures additional {@link PropertySource}s that map OIDC discovery metadata

--- a/oauth2/src/test/groovy/com/okta/spring/boot/oauth/AutoConfigConditionalTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/boot/oauth/AutoConfigConditionalTest.groovy
@@ -74,7 +74,7 @@ import org.testng.annotations.AfterClass
 import org.testng.annotations.BeforeClass
 import org.testng.annotations.Test
 
-import javax.servlet.Filter
+import jakarta.servlet.Filter
 import java.util.function.Supplier
 import java.util.stream.Collectors
 import java.util.stream.Stream


### PR DESCRIPTION
Addressing issue #530 

Updated `oauth2` project to use `jakarta` rather than `javax`. This is due to Spring Boot 3.x requiring the usage of `jakarta` instead of `javax` (see also: [https://spring.io/blog/2022/05/24/preparing-for-spring-boot-3-0](https://spring.io/blog/2022/05/24/preparing-for-spring-boot-3-0))