### PR TITLE
Remove version from `dependency-check-maven` plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,6 @@
              <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>8.0.0</version>
              </plugin>
           </plugins>
        </pluginManagement>


### PR DESCRIPTION
Latest plugin version will automatically be picked up from parent project (https://github.com/okta/okta-java-parent/blob/master/pom.xml#L153).