### PR TITLE
Cleanup CVE suppressions and deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,13 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.4.11</version>
+                <version>1.4.13</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.4.13</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -19,18 +19,22 @@
   -->
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
-    <!-- See https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in -->
-    <suppress>
-        <notes><![CDATA[Ignored since it is deemed "won't fix" by the library authors.]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml.*$</packageUrl>
-        <cve>CVE-2022-1471</cve>
+    <!-- False positive, see https://github.com/jeremylong/DependencyCheck/issues/5943 -->
+    <suppress base="true">
+       <notes>
+          <![CDATA[ FP per issue #5943 ]]>
+       </notes>
+       <packageUrl regex="true">^pkg:maven/org\.eclipse\.jgit/org\.eclipse\.jgit(\.[\w]*)*@6\.7\..*$</packageUrl>
+       <cve>CVE-2023-4759</cve>
     </suppress>
 
-    <!-- False Positive: See https://github.com/jeremylong/DependencyCheck/issues/5779 -->
+    <!-- False positive, see https://github.com/jeremylong/DependencyCheck/issues/5912 -->
     <suppress>
-        <notes><![CDATA[FP per issue #5779]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$</packageUrl>
-        <cve>CVE-2023-35116</cve>
+       <notes>
+          <![CDATA[ FP per issue #5012 ]]>
+       </notes>
+       <packageUrl regex="true">^pkg:maven/io\.netty/netty-.*@.*$</packageUrl>
+       <cve>CVE-2023-4586</cve>
     </suppress>
 
 </suppressions>


### PR DESCRIPTION
- Bump `ch.qos.logback:logback-classic` from 1.4.11 to 1.4.13
- Add `ch.qos.logback:logback-core` v1.4.13 to fix cve
- Cleanup CVE suppression file and add new entries.