### PR TITLE
OKTA-595963 made it possible to set authorities claim name from config

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaJwtAuthenticationConverter.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaJwtAuthenticationConverter.java
@@ -15,6 +15,7 @@
  */
 package com.okta.spring.boot.oauth;
 
+import com.okta.spring.boot.oauth.config.OktaOAuth2Properties;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
@@ -28,6 +29,20 @@ final class OktaJwtAuthenticationConverter extends JwtAuthenticationConverter {
         this.setJwtGrantedAuthoritiesConverter(source -> {
             Collection<GrantedAuthority> result = originalConverter.convert(source);
             result.addAll(TokenUtil.tokenClaimsToAuthorities(source.getClaims(), groupClaim));
+            return result;
+        });
+    }
+
+    public OktaJwtAuthenticationConverter(OktaOAuth2Properties oktaOAuth2Properties) {
+        JwtGrantedAuthoritiesConverter originalConverter = new JwtGrantedAuthoritiesConverter();
+
+        if (oktaOAuth2Properties.getAuthoritiesClaimName() != null) {
+            originalConverter.setAuthoritiesClaimName(oktaOAuth2Properties.getAuthoritiesClaimName());
+        }
+
+        this.setJwtGrantedAuthoritiesConverter(source -> {
+            Collection<GrantedAuthority> result = originalConverter.convert(source);
+            result.addAll(TokenUtil.tokenClaimsToAuthorities(source.getClaims(), oktaOAuth2Properties.getGroupsClaim()));
             return result;
         });
     }

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2ResourceServerAutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2ResourceServerAutoConfig.java
@@ -63,7 +63,7 @@ class OktaOAuth2ResourceServerAutoConfig {
 
     @Bean
     public JwtAuthenticationConverter jwtAuthenticationConverter(OktaOAuth2Properties oktaOAuth2Properties) {
-        return new OktaJwtAuthenticationConverter(oktaOAuth2Properties.getGroupsClaim());
+        return new OktaJwtAuthenticationConverter(oktaOAuth2Properties);
     }
 
     @Bean

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/config/OktaOAuth2Properties.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/config/OktaOAuth2Properties.java
@@ -67,6 +67,11 @@ public final class OktaOAuth2Properties implements Validator {
     private String groupsClaim = "groups";
 
     /**
+     * The token claim name to map authorities
+     */
+    private String authoritiesClaimName;
+
+    /**
      * URL to redirect to after an RP-Initiated logout (SSO Logout).
      */
     private String postLogoutRedirectUri;
@@ -126,6 +131,14 @@ public final class OktaOAuth2Properties implements Validator {
 
     public void setGroupsClaim(String groupsClaim) {
         this.groupsClaim = groupsClaim;
+    }
+
+    public String getAuthoritiesClaimName() {
+        return authoritiesClaimName;
+    }
+
+    public void setAuthoritiesClaimName(String authoritiesClaimName) {
+        this.authoritiesClaimName = authoritiesClaimName;
     }
 
     public Set<String> getScopes() {

--- a/oauth2/src/test/groovy/com/okta/spring/boot/oauth/OktaJwtAuthenticationConverterTest.groovy
+++ b/oauth2/src/test/groovy/com/okta/spring/boot/oauth/OktaJwtAuthenticationConverterTest.groovy
@@ -15,6 +15,7 @@
  */
 package com.okta.spring.boot.oauth
 
+import com.okta.spring.boot.oauth.config.OktaOAuth2Properties
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.jwt.Jwt
 import org.testng.annotations.Test
@@ -43,6 +44,28 @@ class OktaJwtAuthenticationConverterTest {
                 new SimpleGrantedAuthority("SCOPE_three"),
                 new SimpleGrantedAuthority("g1"),
                 new SimpleGrantedAuthority("g2"))
+    }
+
+    @Test
+    void extractAuthorities_customClaimNameTest() {
+
+        // these maps must not be empty
+        def jwt = new Jwt("foo", Instant.now(), Instant.now().plusMillis(1000L), [simple: "value"], [
+            permissions: ["one", "two", "three"],
+            myGroups   : ["g1", "g2"]
+        ])
+
+        def properties = new OktaOAuth2Properties(null)
+        properties.setGroupsClaim("myGroups")
+        properties.setAuthoritiesClaimName("permissions")
+
+        def authorities = new OktaJwtAuthenticationConverter(properties).convert(jwt).getAuthorities()
+        assertThat authorities, hasItems(
+            new SimpleGrantedAuthority("SCOPE_one"),
+            new SimpleGrantedAuthority("SCOPE_two"),
+            new SimpleGrantedAuthority("SCOPE_three"),
+            new SimpleGrantedAuthority("g1"),
+            new SimpleGrantedAuthority("g2"))
     }
 
     @Test


### PR DESCRIPTION
The authorities claims are named "permissions",  not scope nor scp - which is the default of JwtGrantedAuthoritiesConverter. Made the authorities claim name configurable.