### PR TITLE
Enforce `nimus-jose-jwt` `9.37.3` in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,11 @@
                 <artifactId>bcprov-jdk18on</artifactId>
                 <version>1.77</version>
             </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>9.37.3</version>
+            </dependency>
 
             <!-- test dependencies -->
             <dependency>


### PR DESCRIPTION
OKTA-699955

https://mvnrepository.com/artifact/org.springframework.security/spring-security-oauth2-jose/6.2.3 pulls in an older version of nimbus-jose-jwt, so we are enforcing a newer `9.37.3` with this PR.