### PR TITLE
OKTA-789927: Move away from orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,11 @@ workflows:
       - jdk21
       - general-platform-helpers/job-semgrep-scan:
            name: "Scan with Semgrep"
-          context:
-            - static-analysis
+           context:
+             - static-analysis
       - snyk-scan:
            name: execute-snyk
-          context:
-            - static-analysis
+           context:
+             - static-analysis
            requires:
              - prepare-snyk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,5 +43,3 @@ workflows:
            name: execute-snyk
            context:
              - static-analysis
-           requires:
-             - prepare-snyk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  general-platform-helpers: okta/general-platform-helpers@1.8
+  general-platform-helpers: okta/general-platform-helpers@1.9
 
 aliases:
 
@@ -35,17 +35,13 @@ workflows:
   build_and_test:
     jobs:
       - jdk21
-      - general-platform-helpers/job-semgrep-prepare:
-           name: semgrep-prepare
       - general-platform-helpers/job-semgrep-scan:
            name: "Scan with Semgrep"
-           requires:
-             - semgrep-prepare
-      - general-platform-helpers/job-snyk-prepare:
-           name: prepare-snyk
-           requires:
-             - jdk21
+          context:
+            - static-analysis
       - snyk-scan:
            name: execute-snyk
+          context:
+            - static-analysis
            requires:
              - prepare-snyk


### PR DESCRIPTION
This moves away from orb-defined jobs when running static analysis tooling.