### PR TITLE
Fix usage of OktaJwtAuthenticationConverter to use constructor with props

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
@@ -181,7 +181,7 @@ final class OktaOAuth2Configurer extends AbstractHttpConfigurer<OktaOAuth2Config
 
     private void configureResourceServerForJwtValidation(HttpSecurity http, OktaOAuth2Properties oktaOAuth2Properties) throws Exception {
         http.oauth2ResourceServer()
-            .jwt().jwtAuthenticationConverter(new OktaJwtAuthenticationConverter(oktaOAuth2Properties.getGroupsClaim()));
+            .jwt().jwtAuthenticationConverter(new OktaJwtAuthenticationConverter(oktaOAuth2Properties));
     }
 
     private void configureResourceServerForOpaqueTokenValidation(HttpSecurity http, OktaOAuth2Properties oktaOAuth2Properties) throws Exception {

--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig.java
@@ -57,7 +57,7 @@ class ReactiveOktaOAuth2ResourceServerHttpServerAutoConfig {
                 final ServerHttpSecurity http = (ServerHttpSecurity) bean;
                 http.oauth2ResourceServer().jwt()
                         .jwtAuthenticationConverter(new ReactiveJwtAuthenticationConverterAdapter(
-                                new OktaJwtAuthenticationConverter(oktaOAuth2Properties.getGroupsClaim())));
+                                new OktaJwtAuthenticationConverter(oktaOAuth2Properties)));
             }
             return bean;
         }


### PR DESCRIPTION
Updated the autoconfiguration to use the OktaJwtAuthenticationConverter constructor that accepts OktaOAuth2Properties instead of the one that accepts a group name. This change allows the authoritiesClaimName property to be used for mapping authorities from the "permissions" claim, ensuring proper configuration and functionality.