### PR TITLE
Upgrade httpclient5 to 5.4.3 to fix security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,11 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>10.2</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>5.4.3</version>
+            </dependency>
 
             <!-- test dependencies -->
             <dependency>


### PR DESCRIPTION
This PR updates the org.apache.httpcomponents.client5 dependency from version 5.4.1 to 5.4.3 to remediate multiple vulnerabilities identified by Snyk.