### PR TITLE
Upgrading org.springframework.security to v6.4.6 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,12 @@
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-crypto</artifactId>
-                <version>6.4.4</version>
+                <version>6.4.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-core</artifactId>
+                <version>6.4.6</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>


### PR DESCRIPTION
This PR updates the org.springframework.security dependency from version 6.4.4 to 6.4.6 to remediate multiple vulnerabilities identified by Snyk.

