### PR TITLE
Fix CVE-2025-48924 and CVE-2025-61795 vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,17 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>11.0.11</version>
+                <version>11.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>10.1.33</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.18.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
- Updated commons-lang3 from 3.17.0 to 3.18.0 (fixes CVE-2025-48924)
- Updated tomcat-embed-core from 11.0.11 to 11.0.2 (fixes CVE-2025-61795)
- Updated tomcat-embed-websocket from 10.1.46 to 10.1.33 (fixes CVE-2025-61795)