### PR TITLE
fixing vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,28 +76,28 @@
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-starter</artifactId>
-                <version>3.0.8</version>
+                <version>3.0.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-security-oauth2</artifactId>
-                <version>3.0.8</version>
+                <version>3.0.8-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-sdk</artifactId>
-                <version>3.0.8</version>
+                <version>3.0.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-integration-tests-common-servlet</artifactId>
-                <version>3.0.8</version>
+                <version>3.0.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-integration-tests-common-servlet</artifactId>
-                <version>3.0.8</version>
+                <version>3.0.8-SNAPSHOT</version>
                 <classifier>tests</classifier>
                 <type>test-jar</type>
                 <scope>test</scope>
@@ -105,12 +105,12 @@
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-integration-tests-common-reactive</artifactId>
-                <version>3.0.8</version>
+                <version>3.0.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-integration-tests-common-reactive</artifactId>
-                <version>3.0.8</version>
+                <version>3.0.8-SNAPSHOT</version>
                 <classifier>tests</classifier>
                 <type>test-jar</type>
                 <scope>test</scope>


### PR DESCRIPTION


tomcat-embed-core: 11.0.2 → 11.0.14
Fixes CVE-2025-61795 and related vulnerabilities

tomcat-embed-websocket: 10.1.33 → 10.1.49
Addresses multiple CVE vulnerabilities in the 10.1.x series

commons-lang3: Explicitly set to 3.18.0
Fixes CVE-2025-48924
