### PR TITLE
Release/3.0.9

### DIFF
--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-coverage</artifactId>

--- a/examples/config-server/pom.xml
+++ b/examples/config-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring.examples</groupId>
         <artifactId>okta-spring-boot-examples</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-cloud-config-example</artifactId>

--- a/examples/hosted-login-code-flow/pom.xml
+++ b/examples/hosted-login-code-flow/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring.examples</groupId>
         <artifactId>okta-spring-boot-examples</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-hosted-code-flow-example</artifactId>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-sdk</artifactId>
-            <version>3.0.9</version>
+            <version>3.0.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
     </parent>
 
     <groupId>com.okta.spring.examples</groupId>

--- a/examples/redirect-code-flow/pom.xml
+++ b/examples/redirect-code-flow/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring.examples</groupId>
         <artifactId>okta-spring-boot-examples</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-redirect-code-flow-example</artifactId>

--- a/examples/siw-jquery/pom.xml
+++ b/examples/siw-jquery/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring.examples</groupId>
         <artifactId>okta-spring-boot-examples</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-siw-jquery-example</artifactId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>3.0.9</version>
+            <version>3.0.10-SNAPSHOT</version>
         </dependency>
 
         <!-- Other standard Spring starters -->

--- a/examples/webflux-resource-server/pom.xml
+++ b/examples/webflux-resource-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring.examples</groupId>
         <artifactId>okta-spring-boot-examples</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-webflux-example</artifactId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>3.0.9</version>
+            <version>3.0.10-SNAPSHOT</version>
         </dependency>
 
         <!-- Other standard Spring starters -->

--- a/integration-tests/common-reactive/pom.xml
+++ b/integration-tests/common-reactive/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/integration-tests/common-servlet/pom.xml
+++ b/integration-tests/common-servlet/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/integration-tests/oauth2-reactive-spring/pom.xml
+++ b/integration-tests/oauth2-reactive-spring/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/integration-tests/oauth2-reactive/pom.xml
+++ b/integration-tests/oauth2-reactive/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/integration-tests/oauth2-servlet-spring/pom.xml
+++ b/integration-tests/oauth2-servlet-spring/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/integration-tests/oauth2-servlet/pom.xml
+++ b/integration-tests/oauth2-servlet/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/oauth2/pom.xml
+++ b/oauth2/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-security-oauth2</artifactId>

--- a/okta-spring-boot-starter/pom.xml
+++ b/okta-spring-boot-starter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-boot-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.okta.spring</groupId>
     <artifactId>okta-spring-boot-parent</artifactId>
-    <version>3.0.9</version>
+    <version>3.0.10-SNAPSHOT</version>
     <name>Okta Spring Boot</name>
     <packaging>pom</packaging>
 
@@ -80,28 +80,28 @@
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-starter</artifactId>
-                <version>3.0.9</version>
+                <version>3.0.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-security-oauth2</artifactId>
-                <version>3.0.9</version>
+                <version>3.0.10-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-sdk</artifactId>
-                <version>3.0.9</version>
+                <version>3.0.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-integration-tests-common-servlet</artifactId>
-                <version>3.0.9</version>
+                <version>3.0.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-integration-tests-common-servlet</artifactId>
-                <version>3.0.9</version>
+                <version>3.0.10-SNAPSHOT</version>
                 <classifier>tests</classifier>
                 <type>test-jar</type>
                 <scope>test</scope>
@@ -109,12 +109,12 @@
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-integration-tests-common-reactive</artifactId>
-                <version>3.0.9</version>
+                <version>3.0.10-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.spring</groupId>
                 <artifactId>okta-spring-boot-integration-tests-common-reactive</artifactId>
-                <version>3.0.9</version>
+                <version>3.0.10-SNAPSHOT</version>
                 <classifier>tests</classifier>
                 <type>test-jar</type>
                 <scope>test</scope>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.spring</groupId>
         <artifactId>okta-spring-boot-parent</artifactId>
-        <version>3.0.9</version>
+        <version>3.0.10-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-spring-sdk</artifactId>


### PR DESCRIPTION
# Okta Spring Boot 3.0.9: Spring Boot 4.x & Spring Security 7.x Support

## Summary
This release brings full support for Spring Boot 4.0.1 and Spring Security 7.0.2, including critical fixes for dependency management and reactive OAuth2 configuration compatibility.

## What's Changed

### ✅ Core Updates
- **Spring Boot:** Upgraded to 4.0.1 (requires Java 17+)
- **Spring Security:** Updated to 7.0.2
- **Spring Framework:** 7.0.2 (managed via Spring Boot)

### ✅ Critical Fixes
1. **Reactive OAuth2 Configuration** - Fixed `NoSuchMethodError` in Spring Security 7.x
   - Refactored ReactiveAuthenticationManager to use proper bean injection
   - Removed problematic lambda-based method calls
   
2. **Commons-Logging Dependency Management** - Added explicit exclusions
   - oauth2 module: spring-security-config, spring-boot-starter-security, spring-test
   - sdk module: spring-test
   - integration-tests modules: spring-boot-starter-security, spring-test
   
3. **Maven Central Validation** - Explicit spring-core version management
   - Added `org.springframework:spring-core:7.0.2` to dependencyManagement
   - Fixes "Dependency management dependency version information is missing" errors

### 📝 Breaking Changes
- **Requires Java 17+** (Spring Boot 4.x minimum)
- No changes to API or configuration
