### PR TITLE
Fix resource server configuration with AuthenticationManagerResolver

### DIFF
--- a/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
+++ b/oauth2/src/main/java/com/okta/spring/boot/oauth/OktaOAuth2Configurer.java
@@ -114,6 +114,13 @@ final class OktaOAuth2Configurer extends AbstractHttpConfigurer<OktaOAuth2Config
                     http.logout(logout -> logout.logoutSuccessHandler(handler));
                 }
 
+                // Check if OAuth2ResourceServerConfigurer is already configured. If it is, skip opaque token configuration.
+                OAuth2ResourceServerConfigurer<HttpSecurity> authenticationManagerResolver = http.getConfigurer(OAuth2ResourceServerConfigurer.class);
+                if (authenticationManagerResolver != null) {
+                    log.debug("AuthenticationManagerResolver is already configured. Skipping opaque token configuration.");
+                    return;
+                }
+
                 // Resource Server Config
                 OAuth2ResourceServerProperties.Opaquetoken propertiesOpaquetoken;
                 try {


### PR DESCRIPTION
This code should fix the issue reported in https://github.com/okta/okta-spring-boot/issues/933.

The issue is caused by Spring Boot not supporting the use of `authenticationManagerResolver()` together with either `jwt()` or `opaqueToken()`.

When the issuer is set to the Org Authorization Server, we now check whether an `AuthenticationManagerResolver` is configured. If it is, we avoid trying to configure opaque token authentication, preventing the conflict and resolving the issue.
